### PR TITLE
Use default value separator for Spring default values

### DIFF
--- a/vividus-http-client/src/main/resources/org/vividus/http/client/spring.xml
+++ b/vividus-http-client/src/main/resources/org/vividus/http/client/spring.xml
@@ -7,14 +7,14 @@
     default-lazy-init="true">
 
     <bean id="keyStoreFactory" class="org.vividus.http.keystore.KeyStoreFactory" >
-        <property name="keyStorePath" value="${http.key-store.path=#{null}}" />
-        <property name="keyStorePassword" value="${http.key-store.password=#{null}}" />
+        <property name="keyStorePath" value="${http.key-store.path:#{null}}" />
+        <property name="keyStorePassword" value="${http.key-store.password:#{null}}" />
         <property name="keyStoreType" value="JKS" />
     </bean>
 
     <bean id="sslContextFactory" class="org.vividus.http.client.SslContextFactory" >
         <property name="keyStoreFactory" ref="keyStoreFactory" />
-        <property name="privateKeyPassword" value="${http.ssl.private-key-password=#{null}}" />
+        <property name="privateKeyPassword" value="${http.ssl.private-key-password:#{null}}" />
     </bean>
 
     <bean id="httpClientFactory" class="org.vividus.http.client.HttpClientFactory">

--- a/vividus-util/src/main/resources/org/vividus/util/spring.xml
+++ b/vividus-util/src/main/resources/org/vividus/util/spring.xml
@@ -20,10 +20,10 @@
     </bean>
 
     <bean id="locationProvider" class="org.vividus.util.LocationProvider">
-        <property name="locale" value="${location.locale=#{T(java.util.Locale).getDefault()}}" />
+        <property name="locale" value="${location.locale:#{T(java.util.Locale).getDefault()}}" />
     </bean>
 
     <bean id="dateUtils" class="org.vividus.util.DateUtils">
-        <constructor-arg value="${location.zone-id=#{T(java.time.ZoneId).systemDefault()}}" />
+        <constructor-arg value="${location.zone-id:#{T(java.time.ZoneId).systemDefault()}}" />
     </bean>
 </beans>

--- a/vividus/src/main/resources/org/vividus/spring-configuration.xml
+++ b/vividus/src/main/resources/org/vividus/spring-configuration.xml
@@ -24,7 +24,7 @@
     <bean class="org.jasypt.spring4.properties.EncryptablePropertyPlaceholderConfigurer">
         <constructor-arg ref="standardPBEStringEncryptor"/>
         <property name="systemPropertiesMode" value="#{T(org.springframework.beans.factory.config.PropertyPlaceholderConfigurer).SYSTEM_PROPERTIES_MODE_OVERRIDE}" />
-        <property name="valueSeparator" value="=" />
+
         <property name="nullValue" value="" />
         <property name="properties" ref="properties" />
     </bean>


### PR DESCRIPTION
Change the separating character between the placeholder variable
and the associated default value from the custom '=' to the default ':'