### PR TITLE
Bump powermock from 2.0.2 to 2.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
         junit:                  '5.5.2',
         junit4Dataprovider:     '2.6',
         mockito:                '3.1.0',
-        powermock:              '2.0.2',
+        powermock:              '2.0.4',
         slf4jTest:              '2.1.1'
     ]
 }


### PR DESCRIPTION
Bumps `powermock` from 2.0.2 to 2.0.4.

Updates `powermock` from 2.0.2 to 2.0.4
- [Release notes](https://github.com/powermock/powermock/releases)
- [Changelog](https://github.com/powermock/powermock/blob/release/2.x/docs/changelog.txt)
- [Commits](powermock/powermock@powermock-2.0.2...powermock-2.0.4)