### PR TITLE
[plugin-db] Add step to wait until data received from SQL request is equal to data from table

### DIFF
--- a/vividus-plugin-rest-api/src/test/java/org/vividus/http/HttpRequestExecutorTests.java
+++ b/vividus-plugin-rest-api/src/test/java/org/vividus/http/HttpRequestExecutorTests.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,6 +56,7 @@ import org.vividus.http.client.HttpResponse;
 import org.vividus.http.client.IHttpClient;
 import org.vividus.http.exception.HttpRequestBuildException;
 import org.vividus.softassert.ISoftAssert;
+import org.vividus.util.wait.WaitMode;
 
 @ExtendWith({ MockitoExtension.class, TestLoggerFactoryExtension.class })
 class HttpRequestExecutorTests
@@ -175,7 +177,7 @@ class HttpRequestExecutorTests
         when(httpClient.execute(argThat(e -> e instanceof HttpRequestBase && URL.equals(e.getURI().toString())),
                 nullable(HttpContext.class))).thenReturn(httpResponse1).thenReturn(httpResponse2);
         httpRequestExecutor.executeHttpRequest(HttpMethod.GET, URL, Optional.empty(),
-            response -> response.getResponseTimeInMs() < RESPONSE_TIME_IN_MS);
+            response -> response.getResponseTimeInMs() < RESPONSE_TIME_IN_MS, new WaitMode(Duration.ofSeconds(1), 2));
         InOrder orderedHttpTestContext = inOrder(httpTestContext);
         verifyHttpTestContext(orderedHttpTestContext, httpResponse1);
         verifyHttpTestContext(orderedHttpTestContext, httpResponse2);

--- a/vividus-util/src/main/java/org/vividus/util/CheckedSupplier.java
+++ b/vividus-util/src/main/java/org/vividus/util/CheckedSupplier.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.util;
+
+@FunctionalInterface
+public interface CheckedSupplier<T, E extends Exception>
+{
+    T get() throws E;
+}

--- a/vividus-util/src/main/java/org/vividus/util/wait/WaitMode.java
+++ b/vividus-util/src/main/java/org/vividus/util/wait/WaitMode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.util.wait;
+
+import java.time.Duration;
+
+public class WaitMode
+{
+    private final Duration duration;
+    private final int retryTimes;
+
+    public WaitMode(Duration duration, int retryTimes)
+    {
+        this.duration = duration;
+        this.retryTimes = retryTimes;
+    }
+
+    public Duration getDuration()
+    {
+        return duration;
+    }
+
+    public int getRetryTimes()
+    {
+        return retryTimes;
+    }
+}

--- a/vividus-util/src/main/java/org/vividus/util/wait/Waiter.java
+++ b/vividus-util/src/main/java/org/vividus/util/wait/Waiter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.util.wait;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import org.vividus.util.CheckedSupplier;
+import org.vividus.util.Sleeper;
+
+public final class Waiter
+{
+    private Waiter()
+    {
+        // Nothing to do
+    }
+
+    public static <T, E extends Exception> T wait(WaitMode waitMode,
+            CheckedSupplier<T, E> valueProvider, Predicate<T> repeatCondition) throws E
+    {
+        long durationInMillis = waitMode.getDuration().toMillis();
+        long expectedTime = System.currentTimeMillis() + durationInMillis;
+        long pollingTimeoutMillis = durationInMillis / waitMode.getRetryTimes();
+        T value;
+        do
+        {
+            value = valueProvider.get();
+            Sleeper.sleep(pollingTimeoutMillis, TimeUnit.MILLISECONDS);
+        }
+        while (repeatCondition.test(value) && System.currentTimeMillis() <= expectedTime);
+        return value;
+    }
+}

--- a/vividus-util/src/test/java/org/vividus/util/wait/WaiterTests.java
+++ b/vividus-util/src/test/java/org/vividus/util/wait/WaiterTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.util.wait;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.vividus.util.CheckedSupplier;
+
+@RunWith(PowerMockRunner.class)
+@SuppressWarnings("unchecked")
+public class WaiterTests
+{
+    @Test
+    public void testOneTime() throws Exception
+    {
+        CheckedSupplier<Boolean, Exception> valueProvider = PowerMockito.mock(CheckedSupplier.class);
+        PowerMockito.when(valueProvider.get()).thenReturn(true);
+        assertTrue(Waiter.wait(new WaitMode(Duration.ZERO, 1), valueProvider, Boolean::booleanValue));
+    }
+
+    @Test
+    public void testMultipleTimes() throws Exception
+    {
+        CheckedSupplier<Boolean, Exception> valueProvider = PowerMockito.mock(CheckedSupplier.class);
+        PowerMockito.when(valueProvider.get()).thenReturn(true).thenReturn(false);
+        assertFalse(Waiter.wait(new WaitMode(Duration.ofSeconds(1), 2), valueProvider, Boolean::booleanValue));
+    }
+}


### PR DESCRIPTION
Step wording:
When I wait for '$duration' duration retrying $retryTimes times while
data from `$sqlQuery` executed against `$dbKey` matching rows using
`$keys` is equal to data from:$table