### PR TITLE
Remove self-registration of event subscribers

### DIFF
--- a/vividus-agent-reportportal/src/main/java/org/vividus/reportportal/config/ReportPortalConfiguration.java
+++ b/vividus-agent-reportportal/src/main/java/org/vividus/reportportal/config/ReportPortalConfiguration.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import com.epam.reportportal.jbehave.ReportPortalStoryReporter;
 import com.epam.reportportal.jbehave.ReportPortalViewGenerator;
-import com.google.common.eventbus.EventBus;
 
 import org.jbehave.core.reporters.StoryReporter;
 import org.jbehave.core.reporters.ViewGenerator;
@@ -48,9 +47,9 @@ public class ReportPortalConfiguration implements InitializingBean
     }
 
     @Bean
-    public AssertionFailureListener assertionFailureListener(EventBus eventBus)
+    public AssertionFailureListener assertionFailureListener()
     {
-        return new AssertionFailureListener(eventBus);
+        return new AssertionFailureListener();
     }
 
     @Bean

--- a/vividus-agent-reportportal/src/main/java/org/vividus/reportportal/listener/AssertionFailureListener.java
+++ b/vividus-agent-reportportal/src/main/java/org/vividus/reportportal/listener/AssertionFailureListener.java
@@ -20,18 +20,12 @@ import java.util.Optional;
 
 import com.epam.reportportal.jbehave.JBehaveContext;
 import com.epam.reportportal.listeners.Statuses;
-import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 import org.vividus.softassert.event.AssertionFailedEvent;
 
 public class AssertionFailureListener
 {
-    public AssertionFailureListener(EventBus eventBus)
-    {
-        eventBus.register(this);
-    }
-
     @Subscribe
     public void onAssertionFailure(@SuppressWarnings("unused") AssertionFailedEvent event)
     {

--- a/vividus-agent-reportportal/src/test/java/org/vividus/reportportal/config/ReportPortalConfigurationTests.java
+++ b/vividus-agent-reportportal/src/test/java/org/vividus/reportportal/config/ReportPortalConfigurationTests.java
@@ -18,13 +18,11 @@ package org.vividus.reportportal.config;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
 import com.epam.reportportal.jbehave.ReportPortalStoryReporter;
-import com.google.common.eventbus.EventBus;
 
 import org.jbehave.core.reporters.StoryReporter;
 import org.junit.jupiter.api.Test;
@@ -52,7 +50,7 @@ class ReportPortalConfigurationTests
     @Test
     void assertionFailureListener()
     {
-        assertNotNull(configuration.assertionFailureListener(mock(EventBus.class)));
+        assertNotNull(configuration.assertionFailureListener());
     }
 
     @Test

--- a/vividus-agent-reportportal/src/test/java/org/vividus/reportportal/listener/AssertionFailureListenerTests.java
+++ b/vividus-agent-reportportal/src/test/java/org/vividus/reportportal/listener/AssertionFailureListenerTests.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import com.epam.reportportal.jbehave.JBehaveContext;
 import com.epam.reportportal.jbehave.JBehaveContext.Story;
 import com.epam.reportportal.listeners.Statuses;
-import com.google.common.eventbus.EventBus;
 
 import org.junit.Test;
 import org.vividus.softassert.event.AssertionFailedEvent;
@@ -33,14 +32,12 @@ public class AssertionFailureListenerTests
     @Test
     public void testOnAssertionFailure()
     {
-        EventBus eventBus = mock(EventBus.class);
-        AssertionFailureListener listener = new AssertionFailureListener(eventBus);
+        AssertionFailureListener listener = new AssertionFailureListener();
         AssertionFailedEvent event = mock(AssertionFailedEvent.class);
         Story story = mock(Story.class);
         JBehaveContext.setCurrentStory(story);
         listener.onAssertionFailure(event);
         verify(story).setCurrentStepStatus(Statuses.FAILED);
-        verify(eventBus).register(listener);
-        verifyNoMoreInteractions(event, story, eventBus);
+        verifyNoMoreInteractions(event, story);
     }
 }

--- a/vividus/src/main/java/org/vividus/softassert/AssertionManager.java
+++ b/vividus/src/main/java/org/vividus/softassert/AssertionManager.java
@@ -32,7 +32,6 @@ public class AssertionManager
     {
         this.eventBus = eventBus;
         this.softAssert = softAssert;
-        eventBus.register(this);
     }
 
     @Subscribe

--- a/vividus/src/test/java/org/vividus/softassert/AssertionManagerTests.java
+++ b/vividus/src/test/java/org/vividus/softassert/AssertionManagerTests.java
@@ -42,7 +42,9 @@ class AssertionManagerTests
     @BeforeEach
     void beforeEach()
     {
-        assertionManager = new AssertionManager(new EventBus(), softAssert);
+        EventBus eventBus = new EventBus();
+        assertionManager = new AssertionManager(eventBus, softAssert);
+        eventBus.register(assertionManager);
     }
 
     @Test


### PR DESCRIPTION
All EventBus subscribers created as Spring beans are registered automatically via SubscriberRegisteringBeanPostProcessor