### PR TITLE
[Travis CI] Delete all *.lock files before caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       script: ./gradlew artifactoryPublish -Dartifactory.publish.contextUrl=http://oss.jfrog.org -Dartifactory.publish.repoKey=oss-snapshot-local -Dartifactory.publish.username=$BINTRAY_USER -Dartifactory.publish.password=$BINTRAY_KEY -Dartifactory.publish.buildInfo=false
 
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - find $HOME/.gradle/caches/ -name "*.lock" -type f -delete -print
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:


### PR DESCRIPTION
*.lock files are created by Gradle workers for synchronized access to the caches