### PR TITLE
[plugin-rest-api] Add generic step to wait for JSON element presence

### DIFF
--- a/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
@@ -39,3 +39,17 @@ Then a JSON element from '
     "fieldToBeIgnored": "valueToBeIgnored"
 }
 ' by the JSON path '$' is equal to '${expected-json}' ignoring extra fields
+
+Scenario: Verify step "When I wait for presence of element by `$jsonPath` for `$duration` duration retrying $retryTimes times$stepsToExecute"
+When I wait for presence of element by `$.json.iteration3` for `PT15S` duration retrying 3 times
+|step                                                                                          |
+|When I initialize the step variable `iteration` with value `#{eval(${iteration:0} + 1)}`      |
+|When I set request headers:                                                                   |
+|{headerSeparator=!,valueSeparator=!}                                                          |
+|!name         !value            !                                                             |
+|!Content-Type !application/json !                                                             |
+|Given request body: {                                                                         |
+|  "iteration${iteration}": ${iteration}                                                       |
+|}                                                                                             |
+|When I send HTTP POST to the relative URL '/post'                                             |
+|Then a JSON element by the JSON path '$.headers.Content-Type' is equal to '"application/json"'|

--- a/vividus-util/src/main/java/org/vividus/util/function/CheckedRunnable.java
+++ b/vividus-util/src/main/java/org/vividus/util/function/CheckedRunnable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.util.function;
+
+@FunctionalInterface
+public interface CheckedRunnable<E extends Exception>
+{
+    void run() throws E;
+}

--- a/vividus-util/src/main/java/org/vividus/util/wait/Waiter.java
+++ b/vividus-util/src/main/java/org/vividus/util/wait/Waiter.java
@@ -17,9 +17,11 @@
 package org.vividus.util.wait;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import org.vividus.util.Sleeper;
+import org.vividus.util.function.CheckedRunnable;
 import org.vividus.util.function.CheckedSupplier;
 
 public final class Waiter
@@ -45,5 +47,16 @@ public final class Waiter
         }
         while (!stopCondition.test(value) && System.currentTimeMillis() <= endTime);
         return value;
+    }
+
+    public <E extends Exception> void wait(CheckedRunnable<E> runnable, BooleanSupplier stopCondition) throws E
+    {
+        wait(
+            () -> {
+                runnable.run();
+                return (Void) null;
+            },
+            alwaysNull -> stopCondition.getAsBoolean()
+        );
     }
 }

--- a/vividus-util/src/test/java/org/vividus/util/wait/WaiterTests.java
+++ b/vividus-util/src/test/java/org/vividus/util/wait/WaiterTests.java
@@ -19,12 +19,15 @@ package org.vividus.util.wait;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
+import org.vividus.util.function.CheckedRunnable;
 import org.vividus.util.function.CheckedSupplier;
 
 @SuppressWarnings("unchecked")
@@ -44,5 +47,13 @@ class WaiterTests
         CheckedSupplier<Boolean, IOException> valueProvider = mock(CheckedSupplier.class);
         when(valueProvider.get()).thenReturn(false).thenReturn(true).thenReturn(false);
         assertTrue(new Waiter(new WaitMode(Duration.ofSeconds(1), 3)).wait(valueProvider, Boolean::booleanValue));
+    }
+
+    @Test
+    void shouldInvokeRunnableOnceBeforeReachingStopCondition() throws IOException
+    {
+        CheckedRunnable<IOException> checkedRunnable = mock(CheckedRunnable.class);
+        new Waiter(new WaitMode(Duration.ZERO, 1)).wait(checkedRunnable, Boolean.TRUE::booleanValue);
+        verify(checkedRunnable, times(1)).run();
     }
 }


### PR DESCRIPTION
The step exeutes sub-steps and waits for a specified amount of time
 until HTTP response body contains an element by the specified JSON path.