### PR TITLE
[tests] Ensure build is not affected by integration tests configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./gradlew sonarqube; fi
       after_success: bash <(curl -s https://codecov.io/bash)
     - stage: "Integration tests"
-      script: ./gradlew :vividus-tests:runStories
+      script: ./gradlew :vividus-tests:runStories -Pvividus.configuration.environments=integration
     - stage: Publish
       if: branch = master AND type IN (push)
       script: ./gradlew artifactoryPublish -Dartifactory.publish.contextUrl=http://oss.jfrog.org -Dartifactory.publish.repoKey=oss-snapshot-local -Dartifactory.publish.username=$BINTRAY_USER -Dartifactory.publish.password=$BINTRAY_KEY -Dartifactory.publish.buildInfo=false

--- a/vividus-tests/src/main/resources/properties/configuration.properties
+++ b/vividus-tests/src/main/resources/properties/configuration.properties
@@ -1,3 +1,3 @@
 configuration.profile=web/headless/chrome
 configuration.suite=integration
-configuration.environments=integration
+configuration.environments=


### PR DESCRIPTION
Gradle task `testVividusInitialization` uses default test project configuration
(configuration.properties) to check that Spring context can start successfully.
`integration` environment declared in `vividus-tests` requires `PATH` and `JAVA_HOME`
 environment variables to be set. But `PATH` variable may have different case on
Windows OS which may lead to build failures. This CL changes default environment
to empty and sets environment for integration tests in CI config.
Fixes #276 