### PR TITLE
Fix NPE when stories are run using JUnit runner

### DIFF
--- a/vividus-bdd-engine/src/main/java/org/vividus/bdd/context/BddRunContext.java
+++ b/vividus-bdd-engine/src/main/java/org/vividus/bdd/context/BddRunContext.java
@@ -29,7 +29,8 @@ public class BddRunContext implements IBddRunContext
 {
     private TestContext testContext;
 
-    private Optional<String> runningBatchKey;
+    // must be initialized for jbehave-junit-runner
+    private Optional<String> runningBatchKey = Optional.of("batch-1");
     private boolean dryRun;
 
     public void putRunningStory(RunningStory story, boolean givenStory)

--- a/vividus-bdd-engine/src/test/java/org/vividus/bdd/context/BddRunContextTests.java
+++ b/vividus-bdd-engine/src/test/java/org/vividus/bdd/context/BddRunContextTests.java
@@ -84,6 +84,12 @@ class BddRunContextTests
     }
 
     @Test
+    void testGetDefaultRunningBatchKey()
+    {
+        assertEquals("batch-1", bddRunContext.getRunningBatchKey());
+    }
+
+    @Test
     void testGetRunningBatchKey()
     {
         bddRunContext.putRunningBatch(BATCH_KEY);


### PR DESCRIPTION
jbehave-junit-runner builds JUnit execution tree before the actual
execution. Also it knows nothing about Vividus batches. As result
when BDD stories are run NPE is thrown, because no batch is running.
This is a fix for regression bug introduced in e083434 (see
EmbedderControlsProvider.getDefault()).