### PR TITLE
Recreate story manager right before batch execution

### DIFF
--- a/vividus-bdd-engine/src/main/java/org/vividus/bdd/BatchedEmbedder.java
+++ b/vividus-bdd-engine/src/main/java/org/vividus/bdd/BatchedEmbedder.java
@@ -95,6 +95,11 @@ public class BatchedEmbedder extends Embedder
                 try
                 {
                     bddRunContext.putRunningBatch(batch);
+
+                    // JBehaveJUnitRunner may have already initialized StoryManager with default PerformableTree and
+                    // EmebedderControls, so we need to reset it and new one will be created in storyManager()
+                    storyManager = null;
+
                     MetaFilter filter = metaFilter();
                     BatchFailures failures = new BatchFailures(embedderControls.verboseFailures());
 


### PR DESCRIPTION
JBehaveJUnitRunner may initialize story manager with default PerformableTree and
EmebedderControls, so story manager should be re-created before actual batch execution

Issues fixed by this change:
 - Fixes #376 (root cause: batch embedder controls are ignored by story manager)
 - Warnings like
    ```
    2020-03-13 18:06:25,876 SpringContextShutdownHook WARN Unable to register Log4j shutdown hook because JVM is shutting down. Using SimpleLogger
    ```
    The root cause of this warning is skipped reporting of `AfterStories` when single batch is used. (Allure report is generated in `AfterStories` by default or in JVM shutdown hook in case of premature end of test execution. When Allure JVM shutdown hook is triggered, Log4j JVM hook is already finished and Log4j is shutdown, as result Allure reporter can't log anything)