### PR TITLE
Do not wait for alert by default

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
@@ -51,7 +51,7 @@ web.wait.page-starts-to-load-timeout=PT0.5S
 web.wait.page-open-timeout=PT10S
 web.wait.window-open-timeout=PT15S
 
-web.alert.wait-for-alert-timeout=PT10S
+web.alert.wait-for-alert-timeout=PT0S
 
 web.steps.page.keep-user-info-for-protocol-redirects=false
 web.steps.js.include-browser-extension-log-entries=false


### PR DESCRIPTION
The default value of 10 s timeout brings into the picture "10s wait after a click" by default