### PR TITLE
Remove exclusion of json-smart library

### DIFF
--- a/vividus-plugin-rest-api/build.gradle
+++ b/vividus-plugin-rest-api/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation(group: 'org.apache.httpcomponents', name: 'httpmime', version: versions.httpclient)
     implementation(group: 'com.jayway.jsonpath', name: 'json-path-assert', version: '2.4.0') {
-        exclude group: 'net.minidev', module: 'json-smart'
         exclude module: 'hamcrest-library'
     }
     implementation(group: 'org.hamcrest', name: 'hamcrest', version: versions.hamcrest)

--- a/vividus-util/build.gradle
+++ b/vividus-util/build.gradle
@@ -12,9 +12,7 @@ dependencies {
     implementation(group: 'org.apache.commons', name: 'commons-lang3', version: versions.commonsLang3)
     implementation(group: 'commons-io', name: 'commons-io', version: versions.commonsIo)
     implementation(group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-properties')
-    implementation(group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0') {
-        exclude group: 'net.minidev', module: 'json-smart'
-    }
+    implementation(group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0')
     implementation(group: 'javax.inject', name: 'javax.inject', version: versions.javaxInject)
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: versions.junit)


### PR DESCRIPTION
We can't completely exclude `json-smart` library, because it's
explicitly referenced in internal API of `json-path` library:
https://github.com/json-path/JsonPath/blob/master/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java#L150-L151

The exclusion causes the errors like:
`java.lang.ClassNotFoundException: net.minidev.json.parser.ParseException`