### PR TITLE
[plugin-web-app] Stop resizing browser before each scenario

### DIFF
--- a/vividus-plugin-web-app/src/main/java/org/vividus/bdd/steps/WebUiVividusSetupSteps.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/bdd/steps/WebUiVividusSetupSteps.java
@@ -19,32 +19,13 @@ package org.vividus.bdd.steps;
 import javax.inject.Inject;
 
 import org.jbehave.core.annotations.AfterScenario;
-import org.jbehave.core.annotations.BeforeScenario;
 import org.jbehave.core.annotations.ScenarioType;
-import org.vividus.selenium.IBrowserWindowSizeProvider;
-import org.vividus.selenium.IWebDriverProvider;
-import org.vividus.selenium.manager.IWebDriverManager;
 import org.vividus.ui.web.action.IWindowsActions;
 
 public class WebUiVividusSetupSteps extends VividusWebDriverSetupSteps
 {
     @Inject private IWindowsActions windowsActions;
-    @Inject private IBrowserWindowSizeProvider browserWindowSizeProvider;
-    @Inject private IWebDriverManager webDriverManager;
     private WindowsStrategy windowsStrategy;
-
-    @Override
-    @BeforeScenario(uponType = ScenarioType.ANY)
-    public void beforeScenario()
-    {
-        super.beforeScenario();
-        IWebDriverProvider webDriverProvider = getWebDriverProvider();
-        if (webDriverProvider.isWebDriverInitialized())
-        {
-            webDriverManager
-                    .resize(browserWindowSizeProvider.getBrowserWindowSize(webDriverProvider.isRemoteExecution()));
-        }
-    }
 
     @AfterScenario(uponType = ScenarioType.ANY)
     public void afterScenario()

--- a/vividus-plugin-web-app/src/test/java/org/vividus/bdd/steps/WebUiVividusSetupStepsTests.java
+++ b/vividus-plugin-web-app/src/test/java/org/vividus/bdd/steps/WebUiVividusSetupStepsTests.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.vividus.selenium.IBrowserWindowSizeProvider;
 import org.vividus.selenium.IWebDriverProvider;
-import org.vividus.selenium.manager.IWebDriverManager;
 import org.vividus.ui.web.action.IWindowsActions;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,12 +32,6 @@ class WebUiVividusSetupStepsTests
 {
     @Mock
     private IWebDriverProvider webDriverProvider;
-
-    @Mock
-    private IBrowserWindowSizeProvider browserWindowSizeProvider;
-
-    @Mock
-    private IWebDriverManager webDriverManager;
 
     @Mock
     private IWindowsActions windowsActions;


### PR DESCRIPTION
The browser is resized on WebDriverCreate event (see BrowserWindowSizeListener).
Resizing before each scenario doesn't make much sense, since it could be managed
by users and cases when browser window size is changed during test execution are
very rare.