### PR TITLE
[plugin-rest-api] Fix wait steps to fail assertion instead of exception

### DIFF
--- a/vividus-plugin-rest-api/src/main/java/org/vividus/bdd/steps/api/JsonResponseValidationSteps.java
+++ b/vividus-plugin-rest-api/src/main/java/org/vividus/bdd/steps/api/JsonResponseValidationSteps.java
@@ -317,9 +317,17 @@ public class JsonResponseValidationSteps
 
     private void assertJsonElementExists(String jsonPath)
     {
-        if (httpTestContext.getResponse() != null)
+        HttpResponse response = httpTestContext.getResponse();
+        if (response != null)
         {
-            doesJsonPathElementsMatchRule(jsonPath, ComparisonRule.GREATER_THAN, 0);
+            if (response.getResponseBody() != null)
+            {
+                doesJsonPathElementsMatchRule(jsonPath, ComparisonRule.GREATER_THAN, 0);
+            }
+            else
+            {
+                softAssert.recordFailedAssertion("HTTP response body is not present");
+            }
         }
     }
 

--- a/vividus-tests/src/main/resources/known-issues.json
+++ b/vividus-tests/src/main/resources/known-issues.json
@@ -22,5 +22,11 @@
     "assertionPattern": ".*Different keys found in node.*",
     "scenarioPattern": "Known issues should be detected and matched for separate JSON assertions",
     "storyPattern": "KnownIssues"
+  },
+  "VVD-5": {
+    "type": "Internal",
+    "assertionPattern": "HTTP response body is not present",
+    "scenarioPattern": "Verify failure in step .*",
+    "storyPattern": "JsonResponseValidationSteps"
   }
 }

--- a/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
@@ -53,3 +53,8 @@ When I wait for presence of element by `$.json.iteration3` for `PT15S` duration 
 |}                                                                                             |
 |When I send HTTP POST to the relative URL '/post'                                             |
 |Then a JSON element by the JSON path '$.headers.Content-Type' is equal to '"application/json"'|
+
+Scenario: Verify failure in step "When I wait for presence of element by `$jsonPath` for `$duration` duration retrying $retryTimes times$stepsToExecute"
+When I wait for presence of element by `$.non-existing` for `PT1S` duration retrying 1 times
+|step                                                                                          |
+|When I send HTTP GET to the relative URL '/status/204'                                        |


### PR DESCRIPTION
JSON wait steps throwed exception
"java.lang.IllegalArgumentException: json string can not be null or empty"
in case of empty HTTP response body (HTTP "204 NO CONTENT"). This exception
 stooped scenario execution and marked it as broken. The changes from this
 commit add graceful handling of such cases and record failed asssertion
(which also can be marked as knownn issue if it's required)