### PR TITLE
[plugin-rest-api] Ignore number types at JSON comparison

### DIFF
--- a/vividus-plugin-rest-api/src/main/java/org/vividus/bdd/steps/api/JsonResponseValidationSteps.java
+++ b/vividus-plugin-rest-api/src/main/java/org/vividus/bdd/steps/api/JsonResponseValidationSteps.java
@@ -21,6 +21,7 @@ import static java.lang.String.join;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -109,7 +110,8 @@ public class JsonResponseValidationSteps
     {
         return actualData ->
         {
-            JsonDiffMatcher jsonMatcher = new JsonDiffMatcher(attachmentPublisher, expectedData).withOptions(options);
+            JsonDiffMatcher jsonMatcher = new JsonDiffMatcher(attachmentPublisher, expectedData).withOptions(options)
+                    .withTolerance(BigDecimal.ZERO);
             jsonMatcher.matches(actualData);
             String differences = jsonMatcher.getDifferences();
 

--- a/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
@@ -58,3 +58,6 @@ Scenario: Verify failure in step "When I wait for presence of element by `$jsonP
 When I wait for presence of element by `$.non-existing` for `PT1S` duration retrying 1 times
 |step                                                                                          |
 |When I send HTTP GET to the relative URL '/status/204'                                        |
+
+Scenario: Verify JSON validator can successfully compare int vs float numbers
+Then a JSON element from '{"number":0.0}' by the JSON path '$.number' is equal to '0'


### PR DESCRIPTION
JSON standard doesn't specify int and float types, there is just a number: https://tools.ietf.org/html/rfc8259#section-6.
However JsonUnit follows another approach during [JSON numbers comparison](https://github.com/lukas-krecan/JsonUnit#numbers):
> If the type differs, the number is different. So 1 and 1.0 are different (int vs. float)

However the ignorance of number type can be achieved by setting the numerical comparison tolerance to `0` (it's `null` by default)