### PR TITLE
[Github Actions] Publish results to SonarQube once

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,15 +55,20 @@ jobs:
 
     - name: Build with Gradle
       env:
+        MATRIX_PLATFORM: ${{ matrix.platform }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: bash
       run: |
-        if [[ -n $SONAR_TOKEN ]]; then
+        if [[ $MATRIX_PLATFORM = "ubuntu-latest" ]]; then
+          if [[ -n $SONAR_TOKEN ]]; then
             ./gradlew build sonarqube -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=vividus -Dsonar.projectKey=vividus-framework_vividus -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=768m"
-        else
+          else
             echo No SONAR_TOKEN, SonarQube analysis will be skipped
             ./gradlew build -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=768m"
+          fi
+        else
+          ./gradlew build
         fi
 
     - name: Publish unit and integration tests reports - ${{ matrix.platform }}


### PR DESCRIPTION
Previously the run for each platform published the results to SonarQube, but it's redundant, since each publishing overrode the results from another platforms. Now the results are published from Ubuntu only.