### PR TITLE
Refine binding of Vividus meta to Allure labels

### DIFF
--- a/vividus-allure-adaptor/build.gradle
+++ b/vividus-allure-adaptor/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation(group: 'ru.yandex.qatools.clay', name: 'clay-utils', version: '2.5')
     implementation(group: 'org.codehaus.groovy', name: 'groovy', version: versions.groovy, classifier: 'indy')
     implementation(group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1')
+    implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: versions.junit)
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')

--- a/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/VividusLabel.java
+++ b/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/VividusLabel.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.bdd.report.allure;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jbehave.core.model.Meta;
+import org.slf4j.LoggerFactory;
+import org.vividus.bdd.model.MetaWrapper;
+
+import io.qameta.allure.SeverityLevel;
+import io.qameta.allure.entity.LabelName;
+import io.qameta.allure.model.Label;
+import io.qameta.allure.model.Link;
+import io.qameta.allure.util.ResultsUtils;
+
+public enum VividusLabel
+{
+    TEST_CASE_ID("testCaseId", Optional.of(ResultsUtils.TMS_LINK_TYPE)),
+    ISSUE_ID("issueId", Optional.of(ResultsUtils.ISSUE_LINK_TYPE)),
+    REQUIREMENT_ID("requirementId", Optional.of("requirement")),
+    SEVERITY(LabelName.SEVERITY.value(), Optional.empty())
+    {
+        @Override
+        public Set<String> extractMetaValues(Meta storyMeta, Meta scenarioMeta)
+        {
+            String deprecatedMetaKey = "testTier";
+            MetaWrapper metaWrapper = new MetaWrapper(scenarioMeta);
+            Optional<String> deprecatedMeta = metaWrapper.getOptionalPropertyValue(deprecatedMetaKey);
+            Optional<String> actualMeta = metaWrapper.getOptionalPropertyValue(getMetaName());
+
+            if (deprecatedMeta.isPresent())
+            {
+                String message;
+                if (actualMeta.isPresent())
+                {
+                    message = "Both deprecated '{}' and new '{}' meta are present, new meta is used, "
+                            + "please, remove usage of the deprecated meta";
+                }
+                else
+                {
+                    message = "Deprecated meta found: '{}'. Use '{}' instead";
+                    actualMeta = deprecatedMeta;
+                }
+                LoggerFactory.getLogger(VividusLabel.class)
+                        .atWarn()
+                        .addArgument(deprecatedMetaKey)
+                        .addArgument(this::getMetaName)
+                        .log(message);
+            }
+
+            return actualMeta
+                    .map(Integer::parseInt)
+                    .map(severity -> SeverityLevel.values()[severity - 1])
+                    .map(SeverityLevel::value)
+                    .map(Set::of)
+                    .orElseGet(Set::of);
+        }
+    },
+    EPIC(LabelName.EPIC.value(), Optional.empty()),
+    FEATURE(LabelName.FEATURE.value(), Optional.empty());
+
+    private final String metaName;
+    private final Optional<String> linkType;
+
+    VividusLabel(String metaName, Optional<String> linkType)
+    {
+        this.metaName = metaName;
+        this.linkType = linkType;
+    }
+
+    String getMetaName()
+    {
+        return metaName;
+    }
+
+    public Set<String> extractMetaValues(Meta storyMeta, Meta scenarioMeta)
+    {
+        return Stream.of(storyMeta, scenarioMeta)
+                .map(MetaWrapper::new)
+                .map(meta -> meta.getPropertyValues(metaName))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public Optional<Link> createLink(String identifier)
+    {
+        return linkType.map(type -> ResultsUtils.createLink(identifier, null, null, type));
+    }
+
+    public Label createLabel(String value)
+    {
+        return ResultsUtils.createLabel(metaName, value);
+    }
+}

--- a/vividus-allure-adaptor/src/test/java/org/vividus/bdd/report/allure/VividusLabelTests.java
+++ b/vividus-allure-adaptor/src/test/java/org/vividus/bdd/report/allure/VividusLabelTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.bdd.report.allure;
+
+import static com.github.valfirst.slf4jtest.LoggingEvent.warn;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import com.github.valfirst.slf4jtest.TestLoggerFactoryExtension;
+
+import org.jbehave.core.model.Meta;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+import io.qameta.allure.model.Label;
+import io.qameta.allure.model.Link;
+
+@ExtendWith(TestLoggerFactoryExtension.class)
+class VividusLabelTests
+{
+    private static final String HTTPS = "https://";
+
+    private static final Map<String, String> LINK_TYPES = Stream.of("tms", "issue", "requirement")
+            .collect(Collectors.toMap(type -> "allure.link." + type + ".pattern", type -> HTTPS + type + "/{}"));
+
+    private static final String SEVERITY = "severity";
+    private static final String TEST_TIER = "testTier";
+
+    private final TestLogger logger = TestLoggerFactory.getTestLogger(VividusLabel.class);
+
+    @BeforeAll
+    static void beforeAll()
+    {
+        LINK_TYPES.forEach(System::setProperty);
+    }
+
+    @AfterAll
+    static void afterAll()
+    {
+        LINK_TYPES.keySet().forEach(System::clearProperty);
+    }
+
+    private Meta createMeta(String metaKey, String metaValue)
+    {
+        return createMeta(Map.of(metaKey, metaValue));
+    }
+
+    private Meta createMeta(Map<String, String> map)
+    {
+        Properties properties = new Properties();
+        properties.putAll(map);
+        return new Meta(properties);
+    }
+
+    @Test
+    void shouldExtractMetaValues()
+    {
+        String metaKey = "issueId";
+        Meta storyMeta = createMeta(metaKey, "VVD-1;VVD-2");
+        Meta scenarioMeta = createMeta(metaKey, "VVD-3; VVD-4");
+        Set<String> metaValues = VividusLabel.ISSUE_ID.extractMetaValues(storyMeta, scenarioMeta);
+        assertThat(metaValues, contains("VVD-1", "VVD-2", "VVD-3", "VVD-4"));
+    }
+
+    @Test
+    void shouldExtractNonDeprecatedSeverity()
+    {
+        String metaKey = SEVERITY;
+        Meta storyMeta = createMeta(metaKey, "1");
+        Meta scenarioMeta = createMeta(metaKey, "2");
+        Set<String> metaValues = VividusLabel.SEVERITY.extractMetaValues(storyMeta, scenarioMeta);
+        assertEquals(Set.of("critical"), metaValues);
+        assertThat(logger.getLoggingEvents(), equalTo(List.of()));
+    }
+
+    @Test
+    void shouldExtractDeprecatedSeverity()
+    {
+        Meta scenarioMeta = createMeta(TEST_TIER, "3");
+        Set<String> metaValues = VividusLabel.SEVERITY.extractMetaValues(new Meta(), scenarioMeta);
+        assertEquals(Set.of("normal"), metaValues);
+        assertThat(logger.getLoggingEvents(), equalTo(List.of(
+                warn("Deprecated meta found: '{}'. Use '{}' instead", TEST_TIER, SEVERITY))));
+    }
+
+    @Test
+    void shouldExtractNonDeprecatedSeverityWhenBothDeprecatedAndNonDeprecatedOnesArePresent()
+    {
+        Meta scenarioMeta = createMeta(Map.of(
+                TEST_TIER, "4",
+                SEVERITY,  "5"
+        ));
+        Set<String> metaValues = VividusLabel.SEVERITY.extractMetaValues(new Meta(), scenarioMeta);
+        assertEquals(Set.of("trivial"), metaValues);
+        assertThat(logger.getLoggingEvents(), equalTo(List.of(
+                warn("Both deprecated '{}' and new '{}' meta are present, new meta is used, "
+                        + "please, remove usage of the deprecated meta", TEST_TIER, SEVERITY))));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "TEST_CASE_ID,   testCaseId",
+            "ISSUE_ID,       issueId",
+            "REQUIREMENT_ID, requirementId",
+            "SEVERITY,       severity",
+            "EPIC,           epic",
+            "FEATURE,        feature"
+    })
+    void shouldCreateLabel(VividusLabel vividusLabel, String expectedName)
+    {
+        String value = "value";
+        Label label = vividusLabel.createLabel(value);
+        assertAll(
+            () -> assertEquals(expectedName, label.getName()),
+            () -> assertEquals(value, label.getValue())
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "TEST_CASE_ID,   tms",
+            "ISSUE_ID,       issue",
+            "REQUIREMENT_ID, requirement"
+    })
+    void shouldCreateLink(VividusLabel vividusLabel, String type)
+    {
+        String identifier = "VVD-5";
+        Optional<Link> optionalLink = vividusLabel.createLink(identifier);
+        assertTrue(optionalLink.isPresent());
+        Link link = optionalLink.get();
+        assertAll(
+            () -> assertEquals(identifier, link.getName()),
+            () -> assertEquals(type, link.getType()),
+            () -> assertEquals(HTTPS + type + "/" + identifier, link.getUrl())
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"SEVERITY", "EPIC", "FEATURE"}, mode = Mode.INCLUDE)
+    void shouldNotCreateLink(VividusLabel vividusLabel)
+    {
+        assertEquals(Optional.empty(), vividusLabel.createLink("any"));
+    }
+}

--- a/vividus-bdd-engine/src/main/java/org/vividus/bdd/model/MetaWrapper.java
+++ b/vividus-bdd-engine/src/main/java/org/vividus/bdd/model/MetaWrapper.java
@@ -17,14 +17,20 @@
 package org.vividus.bdd.model;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jbehave.core.model.Meta;
 
 public class MetaWrapper
 {
+    private static final char META_VALUES_SEPARATOR = ';';
+
     private final Meta meta;
 
     public MetaWrapper(Meta meta)
@@ -52,5 +58,12 @@ public class MetaWrapper
     {
         String value = meta.getProperty(propertyName);
         return value.isEmpty() ? Optional.empty() : Optional.of(value);
+    }
+
+    public Set<String> getPropertyValues(String propertyName)
+    {
+        return Stream.of(StringUtils.split(meta.getProperty(propertyName), META_VALUES_SEPARATOR))
+                .map(StringUtils::trim)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/vividus-bdd-engine/src/test/java/org/vividus/bdd/model/MetaWrapperTests.java
+++ b/vividus-bdd-engine/src/test/java/org/vividus/bdd/model/MetaWrapperTests.java
@@ -17,13 +17,20 @@
 package org.vividus.bdd.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import org.jbehave.core.model.Meta;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class MetaWrapperTests
 {
@@ -36,5 +43,30 @@ class MetaWrapperTests
         when(meta.getProperty(propertyName)).thenReturn(propertyValue);
         MetaWrapper metaWrapper = new MetaWrapper(meta);
         assertEquals(Optional.of(propertyValue), metaWrapper.getOptionalPropertyValue(propertyName));
+    }
+
+    static Stream<Arguments> metaValues()
+    {
+        return Stream.of(
+                arguments("gh-25;gh-128;gh-25", Set.of("gh-25", "gh-128")),
+                arguments("",                   Set.of())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("metaValues")
+    void testGetPropertyValues(String value, Set<String> expected)
+    {
+        String name = "testCaseId";
+        Properties properties = new Properties();
+        properties.setProperty(name, value);
+        Meta meta = new Meta(properties);
+        assertEquals(expected, new MetaWrapper(meta).getPropertyValues(name));
+    }
+
+    @Test
+    void testGetPropertyValuesForNonExistentMeta()
+    {
+        assertEquals(Set.of(), new MetaWrapper(new Meta()).getPropertyValues("non-existent"));
     }
 }

--- a/vividus-tests/src/main/resources/properties/suite/integration/suite.properties
+++ b/vividus-tests/src/main/resources/properties/suite/integration/suite.properties
@@ -6,7 +6,7 @@ bdd.story-loader.batch-1.resource-include-patterns=*.story
 bdd.batch-1.threads=5
 bdd.batch-1.story-execution-timeout=PT10M
 bdd.variables.batch-1.locale=ca
-bdd.batch-1.meta-filters=groovy: !skip && group != 'vividus-plugin-ssh' && !locale || locale.toString().tokenize(' ').contains('${bdd.variables.batch-1.locale}')
+bdd.batch-1.meta-filters=groovy: !skip && epic != 'vividus-plugin-ssh' && !locale || locale.toString().tokenize(' ').contains('${bdd.variables.batch-1.locale}')
 
 bdd.story-loader.batch-2.resource-location=story/integration
 bdd.story-loader.batch-2.resource-include-patterns=Batch-level variables and meta-filters.story

--- a/vividus-tests/src/main/resources/properties/suite/suite.properties
+++ b/vividus-tests/src/main/resources/properties/suite/suite.properties
@@ -1,0 +1,2 @@
+system.allure.link.issue.pattern=https://github.com/vividus-framework/vividus/issues/{}
+system.allure.link.requirement.pattern=https://github.com/vividus-framework/vividus/issues/{}

--- a/vividus-tests/src/main/resources/story/integration/Batch-level variables and meta-filters.story
+++ b/vividus-tests/src/main/resources/story/integration/Batch-level variables and meta-filters.story
@@ -1,7 +1,8 @@
 Description: Integration tests for batch-level variables and meta-filters
 
 Meta:
-    @group variables
+    @epic vividus-bdd-engine
+    @feature variables
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/integration/ButtonStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ButtonStepsTests.story
@@ -1,7 +1,7 @@
 Description: Integration tests for ButtonSteps class.
 
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/integration/DragAndDropSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/DragAndDropSteps.story
@@ -1,5 +1,5 @@
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Scenario: Step verification 'When I drag element located `$origin` and drop it at $location of element located `$target`'
 Given I am on a page with the URL 'https://4qp6vjp319.codesandbox.io/'

--- a/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
@@ -1,7 +1,7 @@
 Description: Integration tests for ElementSteps class.
 
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/integration/Encryption.story
+++ b/vividus-tests/src/main/resources/story/integration/Encryption.story
@@ -1,7 +1,8 @@
 Description: Integration tests for encryption functionality
 
 Meta:
-    @group encryption
+    @epic vividus-core
+    @feature encryption
 
 Scenario: Verify decrypted value is loaded from properties
 Then `${encrypted-variable}` is equal to `my-secret`

--- a/vividus-tests/src/main/resources/story/integration/EnvironmentVariable.story
+++ b/vividus-tests/src/main/resources/story/integration/EnvironmentVariable.story
@@ -1,7 +1,8 @@
 Description: Integration tests for environment variables
 
 Meta:
-    @group environment-variables
+    @epic vividus-core
+    @feature environment-variables
 
 Scenario: Verify environment variable is loaded from local system
 Then `${java}` matches `.*(jdk|jre){1}.*`

--- a/vividus-tests/src/main/resources/story/integration/ExcelSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/ExcelSteps.story
@@ -1,5 +1,5 @@
 Meta:
-    @group vividus-plugin-excel
+    @epic vividus-plugin-excel
 
 Lifecycle:
 Before:

--- a/vividus-tests/src/main/resources/story/integration/ExecutableSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/ExecutableSteps.story
@@ -1,7 +1,8 @@
 Description: Integration tests for ExecutableSteps class.
 
 Meta:
-    @group executable-steps
+    @epic vividus-core
+    @feature executable-steps
 
 Scenario: Step verification When I iterate while counter is $comparisonRule `$limit` with increment `$increment` starting from `$seed`:$stepsToExecute
 

--- a/vividus-tests/src/main/resources/story/integration/Expressions.story
+++ b/vividus-tests/src/main/resources/story/integration/Expressions.story
@@ -1,7 +1,8 @@
 Description: Integration tests for various Vividus expressions
 
 Meta:
-    @group expressions
+    @epic vividus-bdd-engine
+    @feature expressions
 
 Scenario: [Deprecated] Verify date generation and format
 When I initialize the scenario variable `currentDate` with value `#{P}`

--- a/vividus-tests/src/main/resources/story/integration/FieldStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/FieldStepsTests.story
@@ -2,7 +2,7 @@ Description: Integration tests for FieldSteps class. Page for verification origi
 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/integration/HtmlSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/HtmlSteps.story
@@ -1,7 +1,7 @@
 Description: Integration tests for HtmlSteps class
 
 Meta:
-    @group vividus-plugin-html
+    @epic vividus-plugin-html
 
 Lifecycle:
 Before:

--- a/vividus-tests/src/main/resources/story/integration/HttpRequest.story
+++ b/vividus-tests/src/main/resources/story/integration/HttpRequest.story
@@ -1,7 +1,7 @@
 Description: Integration tests for ApiSteps functionality
 
 Meta:
-    @group vividus-plugin-rest-api
+    @epic vividus-plugin-rest-api
 
 Scenario: Verify method DEBUG is supported
 When I issue a HTTP DEBUG request for a resource with the URL 'http://example.org/'

--- a/vividus-tests/src/main/resources/story/integration/ImageStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ImageStepsTests.story
@@ -1,5 +1,5 @@
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Scenario: Step verification When I hover a mouse over an image with the src '$src'
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'

--- a/vividus-tests/src/main/resources/story/integration/JWT.story
+++ b/vividus-tests/src/main/resources/story/integration/JWT.story
@@ -1,7 +1,8 @@
 Description: Tests to demonstrate working with JSON Web Tokens (JWTs)
 
 Meta:
-    @group JWT
+    @epic vividus-examples
+    @feature JWT
 
 Scenario: Decode/encode JWTs, validate extracked jsons
 When I initialize the scenario variable `JWT` with value `#{loadResource(JWT.txt)}`

--- a/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
@@ -1,7 +1,7 @@
 Description: Integration tests for JsonResponseValidationSteps class (base website http://jsonpath.herokuapp.com/)
 
 Meta:
-    @group vividus-plugin-rest-api
+    @epic vividus-plugin-rest-api
 
 Lifecycle:
 Before:

--- a/vividus-tests/src/main/resources/story/integration/KnownIssues.story
+++ b/vividus-tests/src/main/resources/story/integration/KnownIssues.story
@@ -1,7 +1,8 @@
 Description: Integration tests for known issues functionality
 
 Meta:
-    @group known-issues
+    @epic vividus-core
+    @feature known-issues
 
 Scenario: Known issue should be detected and matched by variable pattern
 When I initialize the scenario variable `var` with value `value-#{generate(regexify '[a-z]{5}')}`

--- a/vividus-tests/src/main/resources/story/integration/LinkStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/LinkStepsTests.story
@@ -1,5 +1,5 @@
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Scenario: Step verification Then context contains list of link items with the text: $expectedLinkItems
 Given I am on a page with the URL 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link'

--- a/vividus-tests/src/main/resources/story/integration/Precondition.story
+++ b/vividus-tests/src/main/resources/story/integration/Precondition.story
@@ -1,5 +1,5 @@
 Meta:
-    @group bdd-engine
+    @epic vividus-bdd-engine
 
 Scenario: Precondition
 Then `precondition-true` is equal to `precondition-true`

--- a/vividus-tests/src/main/resources/story/integration/ResourceCheckSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/ResourceCheckSteps.story
@@ -1,7 +1,7 @@
 Description: Integration tests for ResourceCheckStes class
 
 Meta:
-    @group vividus-plugin-rest-to-web-api
+    @epic vividus-plugin-rest-to-web-api
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/integration/RestApiStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/RestApiStepsTests.story
@@ -1,7 +1,7 @@
 Description: Integration tests for REST API steps
 
 Meta:
-    @group vividus-plugin-rest-api
+    @epic vividus-plugin-rest-api
 
 Lifecycle:
 Before:

--- a/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
@@ -1,5 +1,5 @@
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Scenario: Scroll RIGHT for element Verify step: When I scroll context to $scrollDirection edge
 Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/scrollableElements.html'

--- a/vividus-tests/src/main/resources/story/integration/SetContextStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/SetContextStepsTests.story
@@ -1,5 +1,5 @@
 Meta:
-    @group plugin-web-app
+    @epic vividus-plugin-web-app
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/integration/SshSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/SshSteps.story
@@ -1,7 +1,7 @@
 Description: Integration tests for SshSteps class (requires enabling of SSH connection to host)
 
 Meta:
-    @group vividus-plugin-ssh
+    @epic vividus-plugin-ssh
 
 Scenario: Verify step 'When I execute commands `$commands` on $server over $protocol'
 When I execute commands `cd /; pwd` on localhost over <protocol>

--- a/vividus-tests/src/main/resources/story/integration/TableTransformers.story
+++ b/vividus-tests/src/main/resources/story/integration/TableTransformers.story
@@ -1,7 +1,8 @@
 Description: Integration tests for various Vividus ExamplesTable transformers
 
 Meta:
-    @group table-transformers
+    @epic vividus-bdd-engine
+    @feature table-transformers
 
 Scenario: Verify FROM_CSV transformer
 Then `<country>` is equal to `Belarus`

--- a/vividus-tests/src/main/resources/story/integration/This Story should not run because GivenStory is failed.story
+++ b/vividus-tests/src/main/resources/story/integration/This Story should not run because GivenStory is failed.story
@@ -1,5 +1,5 @@
 Meta:
-    @group bdd-engine
+    @epic vividus-bdd-engine
 
 GivenStories: /story/integration/KnownIssues.story
 

--- a/vividus-tests/src/main/resources/story/integration/Use GivenStories.story
+++ b/vividus-tests/src/main/resources/story/integration/Use GivenStories.story
@@ -1,5 +1,5 @@
 Meta:
-    @group bdd-engine
+    @epic vividus-bdd-engine
 
 GivenStories: /story/integration/Precondition.story
 

--- a/vividus-tests/src/main/resources/story/integration/VariableTests.story
+++ b/vividus-tests/src/main/resources/story/integration/VariableTests.story
@@ -1,7 +1,8 @@
 Description: Integration tests for variables
 
 Meta:
-    @group variables
+    @epic vividus-bdd-engine
+    @feature variables
 
 Scenario: Verify default variables
 Then `1` is = `${key:1}`

--- a/vividus-tests/src/main/resources/story/integration/WaitStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/WaitStepsTests.story
@@ -1,7 +1,7 @@
 Description: Integration tests for WaitSteps class.
 
 Meta:
-    @group vividus-plugin-web-app
+    @epic vividus-plugin-web-app
 
 Scenario: Step verification I wait until element located '$locator' disappears
 Given I am on a page with the URL 'https://www.w3schools.com/jQuery/tryit.asp?filename=tryjquery_hide_slow'

--- a/vividus-tests/src/main/resources/story/integration/XmlSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/XmlSteps.story
@@ -1,7 +1,7 @@
 Description: Integration tests for XmlSteps class
 
 Meta:
-    @group vividus-plugin-xml
+    @epic vividus-plugin-xml
 
 Lifecycle:
 Before:

--- a/vividus-tests/src/main/resources/story/system/ApplitoolsVisualStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/ApplitoolsVisualStepsTests.story
@@ -1,7 +1,7 @@
 Description: System tests for Applitools Visual plugin steps
 
 Meta:
-    @group vividus-plugin-applitools
+    @epic vividus-plugin-applitools
 
 Lifecycle:
 Examples:

--- a/vividus-tests/src/main/resources/story/system/DatabaseStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/DatabaseStepsTests.story
@@ -1,7 +1,8 @@
 Description: Integration tests for DatabaseSteps class
 
 Meta:
-  @group vividus-plugin-db
+    @epic vividus-plugin-db
+    @requirementId 435
 
 Scenario: Verify step: 'When I merge `$left` and `$right` and save result to $scopes variable `$variableName`'
 When I execute SQL query `

--- a/vividus-tests/src/main/resources/story/system/MongodbStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/MongodbStepsTests.story
@@ -1,7 +1,8 @@
 Description: Integration tests for MongoDbSteps class
 
 Meta:
-  @group vividus-plugin-mongodb
+    @epic vividus-plugin-mongodb
+    @requirementId 435
 
 Scenario: Set up
 When I initialize the STORY variable `collectionName` with value `#{generate(regexify '[a-z]{15}')}`

--- a/vividus-tests/src/main/resources/story/system/VisualStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/VisualStepsTests.story
@@ -1,7 +1,7 @@
 Description: System tests for Visual plugin steps
 
 Meta:
-    @group vividus-plugin-visual
+    @epic vividus-plugin-visual
 
 Lifecycle:
 Examples:

--- a/vividus/src/main/resources/properties/defaults/default.properties
+++ b/vividus/src/main/resources/properties/defaults/default.properties
@@ -11,7 +11,7 @@ http.max-total-connections=80
 http.max-connections-per-route=60
 
 # More info about meta filters: https://jbehave.org/reference/stable/meta-filtering.html
-# bdd.all-meta-filters=groovy: (testTier == '1' || testTier == '2') && regression --- All tests of tier 1 or tier 2 levels and marked as 'regression'
+# bdd.all-meta-filters=groovy: (severity == '1' || severity == '2') && regression --- All tests of severity 1 or severity 2 levels and marked as 'regression'
 # bdd.all-meta-filters=+testType UI +regression -skip --- All tests with '@testType UI' marked as 'regression' and not marked as 'skip'
 bdd.all-meta-filters=groovy: !skip && (${bdd.meta-filters})
 bdd.meta-filters=true
@@ -69,8 +69,5 @@ location.locale=en_US
 output.directory=output
 
 known-issue-provider.fileName=known-issues.json
-
-system.allure.link.tms.pattern=
-system.allure.link.issue.pattern=
 
 soft-assert.fail-fast=false


### PR DESCRIPTION
Links in Allure report are generated from the following meta:
- `@testCaseId`
- `@issueId`
- `@requirementId`

The corresponding properties to define link URL patterns are:
- `system.allure.link.tms.pattern`
- `system.allure.link.issue.pattern`
- `system.allure.link.requirement.pattern`

Meta `@testTier` is deprecated in favor of new meta `@severity` to
keep consistency in the reporting. The acceptable range of values
is left unchanged: 1..5.

Meta `@group` is no more mapped to Allure labels since it's not
used in the reporting. But it's still can be used by users to
mark stories and scenarios for filtering.

Meta `@epic` and `@feature` are reserved for future use in Allure
Behaviors plugin.