### PR TITLE
[plugin-web-app] Swallow error quietly in case of unsuccessful scroll

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-element-into-viewport-center.js
+++ b/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-element-into-viewport-center.js
@@ -13,7 +13,7 @@ var exit = arguments[arguments.length-1];
         setTimeout(scrollElementIntoViewportCenter, 500);
     }
     catch(e) {
-        console.error(e, e.stack)
+        // swallow error quietly
     }
     exit();
 }) ();


### PR DESCRIPTION
There are use-cases when it's required to check browser console log
to verify the application works as expected. The console errors from
vividus brings unexpected useless noise here.