### PR TITLE
[GithubActions] Ignore certificate errors for Integration tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -95,9 +95,10 @@ jobs:
 
     - name: Integration tests
       if: matrix.platform == 'ubuntu-latest'
-      run: | 
+      run: |
         ./gradlew :vividus-tests:runStories -Pvividus.configuration.environments=integration \
-                                            -Pvividus.allure.history-directory=output/history/integration-tests
+                                            -Pvividus.allure.history-directory=output/history/integration-tests \
+                                            -Pvividus.web.driver.CHROME.command-line-arguments="--headless --hide-scrollbars --ignore-certificate-errors"
 
     - name: Publish Integration tests report
       if: matrix.platform == 'ubuntu-latest' && always()


### PR DESCRIPTION
*.w3schools.com certificate is expired, need to ignore the error
to make integration tests passed