### PR TITLE
[plugin-web-app] Round window.scrollY at page scroll

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-to-end-of-page.js
+++ b/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-to-end-of-page.js
@@ -1,7 +1,7 @@
 var exit = arguments[arguments.length-1];
 (scrollToEndOfPage = function() {
     bottom = document.body.scrollHeight;
-    current = window.innerHeight + window.scrollY;
+    current = window.innerHeight + Math.round(window.scrollY);
     if((bottom - current) > 0) { 
         window.scrollTo(0, bottom);
         setTimeout('scrollToEndOfPage()', 40);


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
`window.scrollY` is a double-precision floating-point value. When display scale on Windows OS is different from 100%, then the returned value may contain a decimal component.

Fixes #486