### PR TITLE
Fix handling of plus character in URL

### DIFF
--- a/vividus-util/src/main/java/org/vividus/util/UriUtils.java
+++ b/vividus-util/src/main/java/org/vividus/util/UriUtils.java
@@ -164,7 +164,7 @@ public final class UriUtils
 
     private static String decode(String data)
     {
-        return URLDecoder.decode(data, StandardCharsets.UTF_8);
+        return URLDecoder.decode(data.replace("+", "%2B"), StandardCharsets.UTF_8);
     }
 
     private static String extractDecodedFragment(String url)

--- a/vividus-util/src/test/java/org/vividus/util/UriUtilsTests.java
+++ b/vividus-util/src/test/java/org/vividus/util/UriUtilsTests.java
@@ -163,6 +163,9 @@ class UriUtilsTests
         "https://somehost:8080/path?key=%23121:14,                    https://somehost:8080/path?key=%23121:14",
         "https://somehost:8080/path?key=%23121:14#fragment,           https://somehost:8080/path?key=%23121:14#fragment",
         "https://somehost:8080/path?key=%23121:14#hash-in%23fragment, https://somehost:8080/path?key=%23121:14#hash-in%23fragment",
+        "http://somehost:8080/path?date=1980-09-26T00:00:00+02:00&country=US, http://somehost:8080/path?date=1980-09-26T00:00:00+02:00&country=US",
+        "http://somehost:8080/path?date=1980-09-26T00%3A00%3A00%2B02%3A00&country=US, http://somehost:8080/path?date=1980-09-26T00:00:00+02:00&country=US",
+        "http://somehost:8080/path?date=1980-09-26T00:00:00%2B02:00&country=US, http://somehost:8080/path?date=1980-09-26T00:00:00+02:00&country=US"
         // CHECKSTYLE:ON
     })
     void testCreateUri(String input, URI expected)


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8179507
https://stackoverflow.com/questions/43375916/urldecoder-is-converting-into-space:
"According to HTML URL Encoding Reference:

URLs cannot contain spaces. URL encoding normally replaces a space with a plus (+) sign or with %20."