### PR TITLE
Add ability to use placeholders in configuration properties

### DIFF
--- a/vividus/src/integrationTest/resources/overriding.properties
+++ b/vividus/src/integrationTest/resources/overriding.properties
@@ -1,2 +1,5 @@
 override-property=override-property-value
 web.visual.baselines-folder=/
+
+profile-to-use=basicprofile
+suite-to-use=integration

--- a/vividus/src/integrationTest/resources/properties/configuration.properties
+++ b/vividus/src/integrationTest/resources/properties/configuration.properties
@@ -1,1 +1,4 @@
 configuration.suite=
+
+profile-to-use=unknown
+environments-to-use=basicenv


### PR DESCRIPTION
The values for properties:
 - configuration.profile
 - configuration.profiles
 - configuration.environments
 - configuration.suite
can include placeholders for another properties now.

The properties used as placeholders may be declared in:
 - configuration.properties
 - overriding.properties

Closes #550 