### PR TITLE
[plugin-web-app] Fix scrolling script

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-element-into-viewport-center.js
+++ b/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-element-into-viewport-center.js
@@ -1,20 +1,32 @@
 var elementToScroll = arguments[0];
 var exit = arguments[arguments.length-1];
-(scrollElementIntoViewportCenter = function() {
-    var currentWindow = window;
-    try {
-        // Check, if we have an access to top level document
-        window.top.document;
-        while (currentWindow !== window.top) {
-            elementToScroll = currentWindow.frameElement;
-            currentWindow = currentWindow.parent;
-        }
-        currentWindow.scrollBy(0, elementToScroll.getBoundingClientRect().top - currentWindow.innerHeight * 0.25);
-        setTimeout(scrollElementIntoViewportCenter, 500);
-    }
-    catch(e) {
-        // swallow error quietly
-    }
-    exit();
-}) ();
+var waitForScroll;
+var currentWindow = window;
 
+try {
+    // Check, if we have an access to top level document
+    window.top.document;
+    while (currentWindow !== window.top) {
+        elementToScroll = currentWindow.frameElement;
+        currentWindow = currentWindow.parent;
+    }
+    currentWindow.addEventListener('scroll', clearTimeoutAndWait, false);
+    currentWindow.scrollBy(0, elementToScroll.getBoundingClientRect().top - currentWindow.innerHeight * 0.25);
+}
+catch(e) {
+    // swallow error quietly
+}
+
+function wait() {
+    waitForScroll = setTimeout(function() {
+        currentWindow.removeEventListener('scroll', clearTimeoutAndWait);
+        exit(true);
+    }, 50);
+}
+
+function clearTimeoutAndWait(event) {
+    currentWindow.clearTimeout(waitForScroll);
+    wait();
+}
+
+wait();


### PR DESCRIPTION
Script scrolling element into viewport center was executed endlessly with timeout 500 seconds;
The strategy brokes the tests for example in the case when the user clicked anchor link, the page has never scrolled to the anchor because of the script;
New approach: Add scroll waiting listener -> Wait for the scroll end -> remove listener -> call selenium exit callback