### PR TITLE
[plugin-web-app] Enable cookie subdomain matching to host

### DIFF
--- a/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/action/CookieManager.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/action/CookieManager.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import org.apache.http.client.CookieStore;
-import org.apache.http.cookie.SetCookie;
+import org.apache.http.cookie.ClientCookie;
 import org.apache.http.impl.cookie.BasicClientCookie;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver.Options;
@@ -125,11 +125,13 @@ public class CookieManager implements ICookieManager
 
     private static org.apache.http.cookie.Cookie createHttpClientCookie(Cookie seleniumCookie)
     {
-        SetCookie httpClientCookie = new BasicClientCookie(seleniumCookie.getName(), seleniumCookie.getValue());
+        BasicClientCookie httpClientCookie = new BasicClientCookie(seleniumCookie.getName(), seleniumCookie.getValue());
         httpClientCookie.setDomain(seleniumCookie.getDomain());
         httpClientCookie.setPath(seleniumCookie.getPath());
         httpClientCookie.setExpiryDate(seleniumCookie.getExpiry());
         httpClientCookie.setSecure(seleniumCookie.isSecure());
+        httpClientCookie.setAttribute(ClientCookie.DOMAIN_ATTR, seleniumCookie.getDomain());
+        httpClientCookie.setAttribute(ClientCookie.PATH_ATTR, seleniumCookie.getPath());
         return httpClientCookie;
     }
 

--- a/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/action/CookieManagerTests.java
+++ b/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/action/CookieManagerTests.java
@@ -16,6 +16,9 @@
 
 package org.vividus.ui.web.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,6 +33,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.ClientCookie;
+import org.apache.http.impl.cookie.BasicClientCookie;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -151,12 +156,18 @@ class CookieManagerTests
         List<org.apache.http.cookie.Cookie> resultCookies = cookieStore.getCookies();
         assertEquals(1, resultCookies.size());
         org.apache.http.cookie.Cookie httpCookie = resultCookies.get(0);
-        assertEquals(seleniumCookie.getDomain(), httpCookie.getDomain());
-        assertEquals(seleniumCookie.getExpiry(), httpCookie.getExpiryDate());
-        assertEquals(seleniumCookie.getName(), httpCookie.getName());
-        assertEquals(seleniumCookie.getPath(), httpCookie.getPath());
-        assertEquals(seleniumCookie.getValue(), httpCookie.getValue());
-        assertEquals(seleniumCookie.isSecure(), httpCookie.isSecure());
+        assertThat(httpCookie, instanceOf(BasicClientCookie.class));
+        BasicClientCookie clientCookie = (BasicClientCookie) httpCookie;
+        assertAll(
+            () -> assertEquals(seleniumCookie.getDomain(), clientCookie.getDomain()),
+            () -> assertEquals(seleniumCookie.getExpiry(), clientCookie.getExpiryDate()),
+            () -> assertEquals(seleniumCookie.getName(), clientCookie.getName()),
+            () -> assertEquals(seleniumCookie.getPath(), clientCookie.getPath()),
+            () -> assertEquals(seleniumCookie.getValue(), clientCookie.getValue()),
+            () -> assertEquals(seleniumCookie.isSecure(), clientCookie.isSecure()),
+            () -> assertEquals(seleniumCookie.getDomain(), clientCookie.getAttribute(ClientCookie.DOMAIN_ATTR)),
+            () -> assertEquals(seleniumCookie.getPath(), clientCookie.getAttribute(ClientCookie.PATH_ATTR))
+        );
     }
 
     private void configureMockedWebDriver()


### PR DESCRIPTION
If the cookie domain does not equal the exact host,
`org.apache.http.cookie.ClientCookie.DOMAIN_ATTR` must be set.
For example: previously cookies with domain '.imdb.com' were
not passed if URL was 'https://www.imdb.com/', only cookies
with domain 'www.imdb.com' were passed.

See implementation details:
`org.apache.http.impl.cookie.BasicDomainHandler#domainMatch`

More information:
- https://hc.apache.org/httpcomponents-client-ga/tutorial/html/statemgmt.html
- https://stackoverflow.com/a/31428811/2067574
- https://stackoverflow.com/a/31428794/2067574