### PR TITLE
[allure-adaptor] Fix report generation when no test was run

### DIFF
--- a/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/AllureReportGenerator.java
+++ b/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/AllureReportGenerator.java
@@ -104,9 +104,9 @@ public class AllureReportGenerator implements IAllureReportGenerator
     {
         wrap(() ->
         {
+            createDirectories(resultsDirectory, reportDirectory, historyDirectory);
             writeCategoriesInfo();
             writeExecutorInfo();
-            createDirectories(reportDirectory, historyDirectory);
             copyDirectory(historyDirectory, resolveHistoryDir(resultsDirectory));
             generateData();
             customizeReport();
@@ -206,10 +206,7 @@ public class AllureReportGenerator implements IAllureReportGenerator
     {
         for (File directory : directories)
         {
-            if (!directory.exists())
-            {
-                FileUtils.forceMkdir(directory);
-            }
+            Files.createDirectories(directory.toPath());
         }
     }
 

--- a/vividus-allure-adaptor/src/test/java/org/vividus/bdd/report/allure/adapter/AllureReportGeneratorTests.java
+++ b/vividus-allure-adaptor/src/test/java/org/vividus/bdd/report/allure/adapter/AllureReportGeneratorTests.java
@@ -139,10 +139,25 @@ public class AllureReportGeneratorTests
         PowerMockito.verifyPrivate(spy, never()).invoke("generateReport");
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     @PrepareForTest({ReportGenerator.class, AllureReportGenerator.class, FileUtils.class})
-    public void testEnd() throws Exception
+    public void testEndWhenResultsDirectoryExists() throws Exception
+    {
+        testEnd();
+    }
+
+    @Test
+    @PrepareForTest({ReportGenerator.class, AllureReportGenerator.class, FileUtils.class})
+    public void testEndWhenResultsDirectoryDoesNotExist() throws Exception
+    {
+        resultsDirectory = new File(testFolder.getRoot(), "allure-results-to-be-created");
+        System.setProperty(ALLURE_RESULTS_DIRECTORY_PROPERTY, resultsDirectory.getAbsolutePath());
+        allureReportGenerator = new AllureReportGenerator(propertyMapper, resourcePatternResolver);
+        testEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void testEnd() throws Exception
     {
         File historyDirectory = testFolder.newFolder();
         allureReportGenerator.setHistoryDirectory(historyDirectory);


### PR DESCRIPTION
If no test is run, then allure results directory is not created.
That leads to exception like:
```
java.nio.file.NoSuchFileException: .../allure-results/categories.json
```

These changes aim to fix this issue by ensuring that allure results directory exists before the report generation start.