### PR TITLE
[bdd-engine] Fix resolving of circular variable references

### DIFF
--- a/vividus-tests/src/main/resources/story/integration/VariableTests.story
+++ b/vividus-tests/src/main/resources/story/integration/VariableTests.story
@@ -64,3 +64,4 @@ Meta:
     @issueId 691
 When I initialize the scenario variable `value` with value `#{removeWrappingDoubleQuotes(${value})}`
 Then `${value}` is equal to `${value}`
+Then `before-${value}-after` is equal to `before-${value}-after`


### PR DESCRIPTION
The previous fix #700 was not good-enough, since it wasn't able to handle circular variable references in complex expressions when the value to process had prefix/postfix before/after the actual variable. Since there is no way to parse and detect circular variables, this solution introduces max nested level of variables (value is 16), if max level is reached, then result is a one cycle of resolutions.