### PR TITLE
Use year-of-era instead of week-based-year in datetime formats

### DIFF
--- a/docs/modules/plugins/pages/plugin-datetime.adoc
+++ b/docs/modules/plugins/pages/plugin-datetime.adoc
@@ -136,15 +136,15 @@ Let's consider the current date is `2020-11-23` and the time is `00:10:01`
 |2020-11-23T00:00:01
 |Current date time -10 mins
 
-|#{generateDate(P, YYYY-MM)}
+|#{generateDate(P, yyyy-MM)}
 |2020-11
 |Current date with custom format
 
-|#{generateDate(P, MM/dd/YYYY)}
+|#{generateDate(P, MM/dd/yyyy)}
 |11/23/2020
 |Current date with a custom format
 
-|#{generateDate(P1D, YY-MM-dd)}
+|#{generateDate(P1D, yy-MM-dd)}
 |20-11-24
 |Current date +1 day with custom format
 
@@ -175,7 +175,7 @@ The expression formats the input date to another format. Additionally, Time Zone
 
 ==== *_Usage_*
 
-[cols="2,>1", options="header"] 
+[cols="2,>1", options="header"]
 |===
 |Expression
 |Result
@@ -187,7 +187,7 @@ The expression formats the input date to another format. Additionally, Time Zone
 |2017-01-13T09:00:42.862
 
 |#{formatDate(2017-01-13T09:00:42.862-0500, yyyy-MM-dd'T'HH:mm:ss.SSS)}
-|Throw exception 
+|Throw exception
 
 |#{formatDate(2017-01-13T09:00:42.862, yyyy-MM-dd'T'HH:mm:ss)}
 |2017-01-13T09:00:42
@@ -236,7 +236,7 @@ The expression formats an input date to the desired format. The input date forma
 
 ==== *_Parameters_*
 
-. `inputDate` - required parameter. Date to format. Date can be in any format but this format should be described in second parameter. 
+. `inputDate` - required parameter. Date to format. Date can be in any format but this format should be described in second parameter.
 . `inputDateFormat` - input date format. Format can be described using standard Java {java-date-time-formatter-link}
 . `desiredFormat` - output date format. Format can be described using standard Java {java-date-time-formatter-link}
 

--- a/vividus-plugin-datetime/src/main/java/org/vividus/bdd/expression/DateExpressionProcessor.java
+++ b/vividus-plugin-datetime/src/main/java/org/vividus/bdd/expression/DateExpressionProcessor.java
@@ -39,7 +39,7 @@ public class DateExpressionProcessor implements IExpressionProcessor
             .compile("^generateDate\\(((-)?P((?:\\d+[YMWD])*)((?:T?\\d+[HMS])*))(,\\s*(.*))?\\)$");
     private static final int GENERATE_DATE_FORMAT_GROUP = 6;
 
-    private static final DateTimeFormatter DATE_TIME = DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss");
+    private static final DateTimeFormatter DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private static final int MINUS_SIGN_GROUP = 2;
     private static final int PERIOD_GROUP = 3;

--- a/vividus-plugin-datetime/src/test/java/org/vividus/bdd/expression/DateExpressionProcessorTests.java
+++ b/vividus-plugin-datetime/src/test/java/org/vividus/bdd/expression/DateExpressionProcessorTests.java
@@ -72,14 +72,14 @@ class DateExpressionProcessorTests
     @ParameterizedTest
     @ValueSource(strings = {
             "-P1D",
-            "P1D(dd-MM-YYYY)",
+            "P1D(dd-MM-yyyy)",
             "P1Y2M3W4D",
             "-P20D",
             "P1DT20H",
             "P1MT10M",
             "PT10H",
             "generateDate(-P1D)",
-            "generateDate(P1D, dd-MM-YYYY)",
+            "generateDate(P1D, dd-MM-yyyy)",
             "generateDate(P1Y2M3W4D)",
             "generateDate(-P20D)",
             "generateDate(P1DT20H)",
@@ -113,9 +113,9 @@ class DateExpressionProcessorTests
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {
             "P5Y1M10D;                    1905-02-11;               P5Y1M10D; ''",
-            "P1Y1M1W(dd-MM-YYYY);         08-02-1901;               P1Y1M1W;  , dd-MM-YYYY",
+            "P1Y1M1W(dd-MM-yyyy);         08-02-1901;               P1Y1M1W;  , dd-MM-yyyy",
             "PT1H2M3S;                    1900-01-01T01:02:03;      PT1H2M3S; ''",
-            "PT61M63S(YYYY'T'HH-mm-ss);   1900T01-02-03;            PT61M63S; , YYYY'T'HH-mm-ss",
+            "PT61M63S(yyyy'T'HH-mm-ss);   1900T01-02-03;            PT61M63S; , yyyy'T'HH-mm-ss",
             "-P1MT1M;                     1899-11-30T23:59:00;      -P1MT1M;  ''",
             "P(MMM);                      Jan;                      P;        , MMM",
             "P(MMMM);                     January;                  P;        , MMMM",
@@ -138,9 +138,9 @@ class DateExpressionProcessorTests
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {
             "generateDate(P5Y1M10D);                    1905-02-11",
-            "generateDate(P1Y1M1W, dd-MM-YYYY);         08-02-1901",
+            "generateDate(P1Y1M1W, dd-MM-yyyy);         08-02-1901",
             "generateDate(PT1H2M3S);                    1900-01-01T01:02:03",
-            "generateDate(PT61M63S, YYYY'T'HH-mm-ss);   1900T01-02-03",
+            "generateDate(PT61M63S, yyyy'T'HH-mm-ss);   1900T01-02-03",
             "generateDate(-P1MT1M);                     1899-11-30T23:59:00",
             "generateDate(P, MMM);                      Jan",
             "generateDate(P, MMMM);                     January",

--- a/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/JsonResponseValidationSteps.story
@@ -29,7 +29,7 @@ When I save a JSON element from response by JSON path '<jsonPath>' to scenario v
 Then `${numberOfBooks}` is equal to `<booksNumber>`
 
 Scenario: Verify step "Then a JSON element from '$json' by the JSON path '$jsonPath' is equal to '$expectedData'$options"
-When I initialize the scenario variable `current-date` with value `#{generateDate(P, YYYY-MM-DD)}`
+When I initialize the scenario variable `current-date` with value `#{generateDate(P, yyyy-MM-DD)}`
 Given I initialize the scenario variable `expected-json` using template `/data/json-validation-template.ftl` with parameters:
 |currentDate   |
 |${current-date}|


### PR DESCRIPTION
See for examples: https://stackoverflow.com/questions/51141995/why-does-formatting-a-date-using-datetimeformatter-with-a-yyyy-pattern-give-the