### PR TITLE
[bdd-engine] Remove redundant ExamplesTable emptiness check

### DIFF
--- a/vividus-bdd-engine/src/main/java/org/vividus/bdd/steps/ParameterConvertersDecorator.java
+++ b/vividus-bdd-engine/src/main/java/org/vividus/bdd/steps/ParameterConvertersDecorator.java
@@ -84,16 +84,13 @@ public class ParameterConvertersDecorator extends ParameterConverters
         if (type == ExamplesTable.class)
         {
             ExamplesTable examplesTable = (ExamplesTable) result;
-            if (!examplesTable.isEmpty())
-            {
-                List<Map<String, String>> rows = examplesTable.getRows();
-                rows.forEach(
-                    row -> row.entrySet().forEach(
-                        cell -> cell.setValue((String) resolvePlaceholders(cell.getValue(), String.class))
-                    )
-                );
-                examplesTable.withRows(rows);
-            }
+            List<Map<String, String>> rows = examplesTable.getRows();
+            rows.forEach(
+                row -> row.entrySet().forEach(
+                    cell -> cell.setValue((String) resolvePlaceholders(cell.getValue(), String.class))
+                )
+            );
+            examplesTable.withRows(rows);
         }
     }
 


### PR DESCRIPTION
The fix for #732 provided in #733 included the check for ExamplesTable emptiness.
The issue was caused by bug in JBEHAVE: https://jbehave.atlassian.net/browse/JBEHAVE-1412.
JBehave bug was fixed and Vividus was updated to use a new version in #746.
Thus the check for ExamplesTable emptiness became redundant.