### PR TITLE
[vividus-plugin-web] Remove searching by inner text of input in checkbox name search attr

### DIFF
--- a/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/action/search/CheckboxNameSearch.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/action/search/CheckboxNameSearch.java
@@ -37,16 +37,6 @@ public class CheckboxNameSearch extends AbstractElementSearchAction implements I
     @Override
     public List<WebElement> search(SearchContext searchContext, SearchParameters parameters)
     {
-        List<WebElement> checkboxLabels = searchCheckboxLabels(searchContext, parameters);
-        return checkboxLabels.isEmpty() ? findElements(searchContext, getXPathLocator(CHECKBOX_LOCATOR), parameters)
-                .stream()
-                .filter(c -> parameters.getValue().equals(getWebElementActions().getElementText(c)))
-                .map(Checkbox::new)
-                .collect(Collectors.toList()) : checkboxLabels;
-    }
-
-    private List<WebElement> searchCheckboxLabels(SearchContext searchContext, SearchParameters parameters)
-    {
         String checkBoxName = parameters.getValue();
         SearchParameters nonDisplayedParameters = new SearchParameters(parameters.getValue(), Visibility.ALL,
                 parameters.isWaitForElement());

--- a/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/action/search/CheckboxNameSearchTests.java
+++ b/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/action/search/CheckboxNameSearchTests.java
@@ -16,8 +16,9 @@
 
 package org.vividus.ui.web.action.search;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -41,7 +42,6 @@ import org.vividus.ui.web.util.LocatorUtil;
 @ExtendWith(MockitoExtension.class)
 class CheckboxNameSearchTests
 {
-    private static final String INPUT_PATTERN = "input[@type='checkbox']";
     private static final String FOR = "for";
     private static final String VALUE = "value";
     private static final String ATTRIBUTE_VALUE = "checkBoxId";
@@ -51,9 +51,8 @@ class CheckboxNameSearchTests
             + "' and (preceding-sibling::input or following-sibling::input or child::input)]");
     private static final By CHECKBOX_LABEL_DEEP_LOCATOR = LocatorUtil
             .getXPathLocator("label[preceding-sibling::input or following-sibling::input or child::input]");
-    private static final By INPUT_LOCATOR = LocatorUtil.getXPathLocator(INPUT_PATTERN);
     private static final By PRECEDING_SIBLING_CHECKBOX_LOCATOR = LocatorUtil
-            .getXPathLocator("preceding-sibling::" + INPUT_PATTERN);
+            .getXPathLocator("preceding-sibling::input[@type='checkbox']");
 
     private final SearchParameters parameters = new SearchParameters(VALUE);
 
@@ -104,64 +103,16 @@ class CheckboxNameSearchTests
     }
 
     @Test
-    void testSearchSuccessByCheckboxLocator()
-    {
-        spy = Mockito.spy(checkboxNameSearch);
-        WebElement checkbox = mock(WebElement.class);
-        when(spy.findElements(eq(searchContext), eq(CHECKBOX_LABEL_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of());
-        when(spy.findElements(eq(searchContext), eq(CHECKBOX_LABEL_DEEP_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of());
-        when(spy.findElements(eq(searchContext), eq(INPUT_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of(checkbox));
-        when(webElementActions.getElementText(checkbox)).thenReturn(VALUE);
-        List<WebElement> foundElements = spy.search(searchContext, parameters);
-        assertEquals(1, foundElements.size());
-        Checkbox foundElement = (Checkbox) foundElements.get(0);
-        assertEquals(checkbox, foundElement.getWrappedElement());
-        assertNull(foundElement.getLabelElement());
-    }
-
-    @Test
-    void testSearchSuccessWrongText()
-    {
-        spy = Mockito.spy(checkboxNameSearch);
-        WebElement checkbox = mock(WebElement.class);
-        WebElement label = mock(WebElement.class);
-        when(spy.findElements(eq(searchContext), eq(CHECKBOX_LABEL_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of());
-        when(spy.findElements(eq(searchContext), eq(CHECKBOX_LABEL_DEEP_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of(label));
-        when(webElementActions.getElementText(label)).thenReturn("wrongText");
-        when(webElementActions.getElementText(checkbox)).thenReturn(VALUE);
-        when(spy.findElements(eq(searchContext), eq(INPUT_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of(checkbox));
-        List<WebElement> foundElements = spy.search(searchContext, parameters);
-        assertEquals(1, foundElements.size());
-        Checkbox foundElement = (Checkbox) foundElements.get(0);
-        assertEquals(checkbox, foundElement.getWrappedElement());
-        assertNull(foundElement.getLabelElement());
-    }
-
-    @Test
     void testSearchSuccessEmptySiblings()
     {
         spy = Mockito.spy(checkboxNameSearch);
-        WebElement checkbox = mock(WebElement.class);
         WebElement label = mock(WebElement.class);
         when(spy.findElements(eq(searchContext), eq(CHECKBOX_LABEL_LOCATOR), any(SearchParameters.class)))
                 .thenReturn(List.of(label));
         when(spy.findElements(eq(searchContext), eq(CHECKBOX_LABEL_DEEP_LOCATOR), any(SearchParameters.class)))
                 .thenReturn(List.of());
-        when(webElementActions.getElementText(checkbox)).thenReturn(VALUE);
         when(label.findElements(PRECEDING_SIBLING_CHECKBOX_LOCATOR)).thenReturn(List.of());
-        when(spy.findElements(eq(searchContext), eq(INPUT_LOCATOR), any(SearchParameters.class)))
-                .thenReturn(List.of(checkbox));
-        List<WebElement> foundElements = spy.search(searchContext, parameters);
-        assertEquals(1, foundElements.size());
-        Checkbox foundElement = (Checkbox) foundElements.get(0);
-        assertEquals(checkbox, foundElement.getWrappedElement());
-        assertNull(foundElement.getLabelElement());
+        assertThat(spy.search(searchContext, parameters), empty());
     }
 
     @Test


### PR DESCRIPTION
- input element is a void element which is not allowed to have nested elements -> https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements
- manual insertion of text inside a void element is considered by browser as invalid and the text is moved out from the element
<img width="247" alt="Screen Shot 2020-08-21 at 13 26 14" src="https://user-images.githubusercontent.com/30923336/90893237-4db62080-e3c7-11ea-85a2-6103e7d6ab17.png">
- programatic insertion of text inside a void element using appendChild(...) results in invisibility of the inserted element
<img width="384" alt="Screen Shot 2020-08-21 at 13 26 55" src="https://user-images.githubusercontent.com/30923336/90893348-80601900-e3c7-11ea-9416-2df3bf7238db.png">
<img width="190" alt="Screen Shot 2020-08-21 at 13 27 01" src="https://user-images.githubusercontent.com/30923336/90893411-95d54300-e3c7-11ea-8d6c-7d526f223c10.png">
