### PR TITLE
[plugin-web-app] Remove empty 'browserVersion' capability

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
@@ -13,12 +13,11 @@ selenium.windows-strategy=DO_NOTHING
 selenium.grid.enabled=false
 selenium.grid.url=https://user:accessKey@ondemand.saucelabs.com/wd/hub
 selenium.grid.capabilities.browserName=
-selenium.grid.capabilities.browserVersion=
 
 environment-configurer.environment.main-application-page=${web-application.main-page-url}
 environment-configurer.profile.remote-execution=#{${selenium.grid.enabled} ? 'ON' : 'OFF'}
 environment-configurer.profile.operating-system=#{${selenium.grid.enabled} ? '${selenium.grid.capabilities.platformName}' : T(org.apache.commons.lang3.SystemUtils).OS_NAME}
-environment-configurer.profile.browser=${selenium.browser} ${selenium.grid.capabilities.browserVersion}
+environment-configurer.profile.browser=${selenium.browser} ${selenium.grid.capabilities.browserVersion=}
 environment-configurer.profile.proxy=#{${proxy.enabled} ? 'ON' : 'OFF'}
 
 # Github token to download Firefox binaries via API: https://github.com/bonigarcia/webdrivermanager#known-issues


### PR DESCRIPTION
When custom Selenium Grid is used, the empty `browserVersion` capability blocks search of the requested browser node