### PR TITLE
[tests] Use Vividus test site for ResourceCheckSteps tests

### DIFF
--- a/vividus-tests/src/main/resources/story/integration/ResourceCheckSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/ResourceCheckSteps.story
@@ -6,7 +6,7 @@ Meta:
 Lifecycle:
 Examples:
 |pageToValidate          |
-|https://www.example.com/|
+|${vividus-test-site-url}|
 
 Scenario: Verification of Then all resources by selector $cssSelector from $html are valid; Source from HTTP response
 When I issue a HTTP GET request for a resource with the URL '<pageToValidate>'


### PR DESCRIPTION
The URL from https://www.example.com/ may behave differently, so we need to use something more stable: Vividus test site

<img width="500" alt="fail" src="https://user-images.githubusercontent.com/5081226/96739294-4eb7fe00-13c8-11eb-9185-8910ab6d8cfe.png">
