### PR TITLE
[tests] Remove redundant property

### DIFF
--- a/vividus-tests/src/main/resources/properties/suite/grid/suite.properties
+++ b/vividus-tests/src/main/resources/properties/suite/grid/suite.properties
@@ -1,3 +1,2 @@
 bdd.story-loader.batch-1.resource-location=story/system
 bdd.story-loader.batch-1.resource-include-patterns=HealthCheck.story
-bdd.batch-1.threads=1


### PR DESCRIPTION
The default number of threads per batch is `1`