### PR TITLE
[plugin-web-app] Fix configuration of 'screen-resolution' capability

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/chrome/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/chrome/profile.properties
@@ -1,2 +1,4 @@
 selenium.browser=chrome
 selenium.screenshot.strategy=VIEWPORT_PASTING
+
+selenium.grid.screen-resolution=1920x1080

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/edge/chromium/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/edge/chromium/profile.properties
@@ -2,3 +2,5 @@ selenium.browser=edge_chromium
 
 selenium.grid.capabilities.platformName=ANY
 selenium.grid.capabilities.browserVersion=80
+
+selenium.grid.screen-resolution=1920x1080

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/edge/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/edge/profile.properties
@@ -4,3 +4,5 @@ selenium.grid.capabilities.version=13
 selenium.grid.capabilities.browserName=MicrosoftEdge
 
 selenium.screenshot.strategy=VIEWPORT_PASTING
+
+selenium.grid.screen-resolution=1920x1080

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/firefox/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/firefox/profile.properties
@@ -1,2 +1,4 @@
 selenium.browser=firefox
 selenium.screenshot.strategy=VIEWPORT_PASTING
+
+selenium.grid.screen-resolution=1920x1080

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/iexplore/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/iexplore/profile.properties
@@ -4,3 +4,5 @@ selenium.grid.capabilities.iedriverVersion=3.141.0
 
 # Workaround for IExplorer: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/1835
 selenium.grid.capabilities.enablePersistentHover=false
+
+selenium.grid.screen-resolution=1920x1080

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/opera/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/opera/profile.properties
@@ -1,2 +1,4 @@
 selenium.browser=opera
 selenium.screenshot.strategy=VIEWPORT_PASTING
+
+selenium.grid.screen-resolution=1920x1080

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/profile.properties
@@ -1,7 +1,5 @@
 bdd.all-meta-filters=groovy: (!layout || layout.contains('desktop')) && !skip && (${bdd.meta-filters})
 
-selenium.grid.screen-resolution=1920x1080
-
 selenium.grid.platform-name=Windows
 selenium.grid.platform-version=10
 

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/safari/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/safari/profile.properties
@@ -7,3 +7,5 @@ selenium.grid.capabilities.prerun=https://gist.githubusercontent.com/saucyalliso
 
 selenium.screenshot.strategy=SIMPLE
 selenium.alert-strategy=ACCEPT
+
+selenium.grid.screen-resolution=


### PR DESCRIPTION
The previous default value of screen-resolution capability (1920x1080) is not universal, e.g. it's not applicable for MacOS platform on SauceLabs.
The 'screen-resolution' fix includes:
- setting of the default value (1920x1080) for Chrome, Edge, Firefox, IE profiles
- setting of the empty value for Safari profile (the empty value will result in default value for the concrete Selenium Grid implementation, e.g. it's 1024x768 for SauceLabs now)