### PR TITLE
[bdd-engine] Exclude transitive spring-context dependency

### DIFF
--- a/vividus-bdd-engine/build.gradle
+++ b/vividus-bdd-engine/build.gradle
@@ -13,7 +13,9 @@ dependencies {
     implementation(group: 'com.google.guava', name: 'guava', version: versions.guava)
     implementation(group: 'com.github.javafaker', name: 'javafaker', version: '1.0.2')
     implementation(group: 'javax.inject', name: 'javax.inject', version: versions.javaxInject)
-    runtimeOnly(group: 'org.vividus', name: 'jbehave-spring', version: versions.jbehave)
+    runtimeOnly(group: 'org.vividus', name: 'jbehave-spring', version: versions.jbehave) {
+        exclude group: 'org.springframework', module: 'spring-context'
+    }
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: versions.junit)
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')


### PR DESCRIPTION
Description:

An attempt was made to call a method that does not exist. The attempt was made from the following location:

    org.springframework.boot.SpringApplication.run(SpringApplication.java:324)

The following method did not exist:
    org.springframework.context.ConfigurableApplicationContext.setApplicationStartup(Lorg/springframework/core/metrics/ApplicationStartup;)V

The method's class, org.springframework.context.ConfigurableApplicationContext, is available from the following locations:
jar:file:.../org.springframework/spring-context/5.2.0.RELEASE/a2638a8295f13ed8511c98a2379507677e1d16fa/spring-context-5.2.0.RELEASE.jar!/org/springframework/context/ConfigurableApplicationContext.class
jar:file.../org.springframework/spring-context/5.3.1/736836c8098981ddabd309a0c15f967594da62bc/spring-context-5.3.1.jar!/org/springframework/context/ConfigurableApplicationContext.class

The class hierarchy was loaded from the following locations:
org.springframework.context.ConfigurableApplicationContext: file:.../org.springframework/spring-context/5.2.0.RELEASE/a2638a8295f13ed8511c98a2379507677e1d16fa/spring-context-5.2.0.RELEASE.jar
