### PR TITLE
[bdd-engine] Fix variables resolution for the values with preceding `}`

### DIFF
--- a/vividus-bdd-engine/src/main/java/org/vividus/bdd/steps/VariableResolver.java
+++ b/vividus-bdd-engine/src/main/java/org/vividus/bdd/steps/VariableResolver.java
@@ -71,7 +71,10 @@ public class VariableResolver
                     {
                         end = i;
                     }
-                    level--;
+                    if (level > 0)
+                    {
+                        level--;
+                    }
                     break;
                 default:
                     break;
@@ -93,7 +96,7 @@ public class VariableResolver
             return resolved;
         }
         String resolvedStr = (String) resolved;
-        int nextScanStartPosition = resolvedStr.indexOf(value.substring(end + 1));
+        int nextScanStartPosition = resolvedStr.indexOf(value.substring(end + 1), start);
         return resolveVariables(nextScanStartPosition, resolvedStr);
     }
 

--- a/vividus-bdd-engine/src/test/java/org/vividus/bdd/steps/VariableResolverTests.java
+++ b/vividus-bdd-engine/src/test/java/org/vividus/bdd/steps/VariableResolverTests.java
@@ -61,7 +61,9 @@ class VariableResolverTests
             " ${var:default},                       var:default,     value, value",
             " ${var:},                              var:,            value, value",
             " '{\"ids\": [\"${var}\", \"12-ce\"]}', var,             value, '{\"ids\": [\"value\", \"12-ce\"]}'",
-            " ${var${varPartName}},                 varPartName,     value, ${varvalue}"
+            " ${var${varPartName}},                 varPartName,     value, ${varvalue}",
+            " '#{exp(\\}{BNS_TRX_ID=, A, ${var})}', var,             value, '#{exp(\\}{BNS_TRX_ID=, A, value)}'",
+            " [JAVA_HOME=${var}].*[^${PATH}].*,     var,             value, [JAVA_HOME=value].*[^${PATH}].*"
     })
     void shouldResolveVariables(String valueToResolve, String variableKey, String variableValue, String expected)
     {

--- a/vividus-tests/src/main/resources/story/integration/VariableTests.story
+++ b/vividus-tests/src/main/resources/story/integration/VariableTests.story
@@ -131,7 +131,9 @@ When I initialize the scenario variable `variable` with value `Variable`
 When I initialize the scenario variable `Variable` with value `nested`
 When I initialize the scenario variable `compositeVariable` with value `expected`
 When I initialize the scenario variable `expected` with value `nested-expected`
-Then `${composite${variable}}`              is equal to `expected`
-Then `${${variable}}`                       is equal to `nested`
-Then `${composite:${composite${variable}}}` is equal to `expected`
-Then `#{eval(${non-existing:0} + 1)}`       is equal to `1`
+When I initialize the scenario variable `complex` with value `[{ids=2}, {ids=0}, {ids=7}, {ids=7}]`
+Then `${composite${variable}}`                                            is equal to `expected`
+Then `${${variable}}`                                                     is equal to `nested`
+Then `${composite:${composite${variable}}}`                               is equal to `expected`
+Then `#{eval(${non-existing:0} + 1)}`                                     is equal to `1`
+Then `#{replaceAllByRegExp("""\},\s\{ids=""", """""", """${complex}""")}` is equal to `[{ids=2077}]`


### PR DESCRIPTION
Fixes #1252 