### PR TITLE
[plugin-web-app] Remove deprecated non-generic steps scrolling vertically

### DIFF
--- a/vividus-plugin-web-app/src/main/java/org/vividus/bdd/steps/ui/web/ScrollSteps.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/bdd/steps/ui/web/ScrollSteps.java
@@ -67,43 +67,4 @@ public class ScrollSteps
             javascriptActions.scrollIntoView(toScroll, true);
         }
     }
-
-    /**
-     * Scrolls to the end of the page with dynamically loading content upon scrolling
-     * Before using step, it is necessary to wait until scroll appears if it exists
-     * <p>
-     * Attribute scroll manages scroll bars in a browser window
-     * when the content of a web page exceeds the size of the current window
-     * </p>
-     * <p>
-     * Actions performed at this step:
-     * </p>
-     * <ul>
-     * <li>Scrolls to the end of the page</li>
-     * </ul>
-     * @deprecated Step will be removed use {@link #scrollContextIn(ScrollDirection)}
-     */
-    @When("I scroll to the end of the page")
-    @Deprecated(forRemoval = true, since = "0.2.1")
-    public void scrollToTheEndOfThePage()
-    {
-        javascriptActions.scrollToEndOfPage();
-    }
-
-    /**
-     * Scrolls to the start of the page
-     * <p>
-     * Actions performed at this step:
-     * </p>
-     * <ul>
-     * <li>Scrolls to the start of the page</li>
-     * </ul>
-     * @deprecated Step will be removed use {@link #scrollContextIn(ScrollDirection)}
-     */
-    @When("I scroll to the start of the page")
-    @Deprecated(forRemoval = true, since = "0.2.1")
-    public void scrollToTheStartOfThePage()
-    {
-        javascriptActions.scrollToStartOfPage();
-    }
 }

--- a/vividus-plugin-web-app/src/main/resources/steps/defaults/scroll.steps
+++ b/vividus-plugin-web-app/src/main/resources/steps/defaults/scroll.steps
@@ -1,5 +1,0 @@
-Composite: When I scroll to the end of the context
-When I scroll context to BOTTOM edge
-
-Composite: When I scroll to the start of the context
-When I scroll context to TOP edge

--- a/vividus-plugin-web-app/src/test/java/org/vividus/bdd/steps/ui/web/ScrollStepsTests.java
+++ b/vividus-plugin-web-app/src/test/java/org/vividus/bdd/steps/ui/web/ScrollStepsTests.java
@@ -122,20 +122,6 @@ class ScrollStepsTests
     }
 
     @Test
-    void testScrollToTheEndOfThePage()
-    {
-        scrollSteps.scrollToTheEndOfThePage();
-        verify(javascriptActions).scrollToEndOfPage();
-    }
-
-    @Test
-    void testScrollToTheStartOfThePage()
-    {
-        scrollSteps.scrollToTheStartOfThePage();
-        verify(javascriptActions).scrollToStartOfPage();
-    }
-
-    @Test
     void shouldScrollElementIntoViewAlignedToATop()
     {
         WebElement webElement = mock(WebElement.class);

--- a/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
@@ -27,20 +27,6 @@ When I scroll context to TOP edge
 When I change context to an element by By.id(current-vertical):a
 Then the text matches '0'
 
-Scenario: Verify step: When I scroll to the end of the context
-When I change context to an element by By.id(current-vertical):a
-When I change context to an element by By.id(scrollable)
-When I scroll to the end of the context
-When I change context to an element by By.id(current-vertical):a
-Then the text matches '\d+'
-
-Scenario: Verify step: When I scroll to the start of the context
-When I change context to an element by By.id(current-vertical):a
-When I change context to an element by By.id(scrollable)
-When I scroll to the start of the context
-When I change context to an element by By.id(current-vertical):a
-Then the text matches '0'
-
 Scenario: Verify step: When I scroll element located `$locator` into view
 Meta:
     @requirementId 436
@@ -57,15 +43,5 @@ Then `${scroll}` is > `0`
 
 Scenario: Scroll TOP for page Verify step: When I scroll context to $scrollDirection edge
 When I scroll context to TOP edge
-When I perform javascript 'return document.documentElement.scrollTop' and save result to the 'scenario' variable 'scroll'
-Then `${scroll}` is = `0`
-
-Scenario: Verify step: When I scroll to the end of the page
-When I scroll to the end of the page
-When I perform javascript 'return document.documentElement.scrollTop' and save result to the 'scenario' variable 'scroll'
-Then `${scroll}` is > `0`
-
-Scenario: Verify step: When I scroll to the start of the page
-When I scroll to the start of the page
 When I perform javascript 'return document.documentElement.scrollTop' and save result to the 'scenario' variable 'scroll'
 Then `${scroll}` is = `0`


### PR DESCRIPTION
Removed steps (deprecated in 0.2.1):
- `When I scroll to the start of the context`
- `When I scroll to the end of the context`
- `When I scroll to the start of the page`
- `When I scroll to the end of the page`

Replacement:
- `When I scroll context to $scrollDirection edge`