### PR TITLE
[plugin-html] Remove deprecated step verifying if HTML contains element

### DIFF
--- a/vividus-plugin-html/src/main/resources/steps/defaults/composite.steps
+++ b/vividus-plugin-html/src/main/resources/steps/defaults/composite.steps
@@ -1,2 +1,0 @@
-Composite: Then HTML `$html` contains element by CSS selector `$cssSelector`
-Then number of elements found by CSS selector `<cssSelector>` in HTML `<html>` is = `1`

--- a/vividus-tests/src/main/resources/story/integration/HtmlSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/HtmlSteps.story
@@ -20,9 +20,6 @@ When I initialize the story variable `html` with value
 </html>
 `
 
-Scenario: Verify step 'Then HTML `$html` contains element by CSS selector `$cssSelector`'
-Then HTML `${html}` contains element by CSS selector `body > h1`
-
 Scenario: Verify step 'Then HTML `$html` contains data `$expectedData` by CSS selector `$cssSelector`'
 Then HTML `${html}` contains data `This is a paragraph.` by CSS selector `body > p`
 


### PR DESCRIPTION
Removed step (deprecated in 0.2.1): Then HTML `$html` contains element by CSS selector `$cssSelector`
Replacement: Then number of elements found by CSS selector `$cssSelector` in HTML `$html` is $comparisonRule `$quantity`