### PR TITLE
[plugin-web-app] Remove not working prerun from web safari profile

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/safari/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/safari/profile.properties
@@ -2,9 +2,6 @@ selenium.browser=safari
 selenium.grid.platform-name=macOS
 selenium.grid.platform-version=10.15
 
-#https://wiki.saucelabs.com/display/DOCS/Setting+Basic+Authentication+in+Safari+with+a+Pre-Run+Executable
-selenium.grid.capabilities.prerun=https://gist.githubusercontent.com/saucyallison/3a73a4e0736e556c990d/raw/d26b0195d48b404628fc12342cb97f1fc5ff58ec/disable_fraud.sh
-
 selenium.screenshot.strategy=SIMPLE
 selenium.alert-strategy=ACCEPT
 


### PR DESCRIPTION
The pre-run executable can only be used for Safari versions up to and including 10.x.