### PR TITLE
[plugin-web-app] Remove deprecated steps switching to frame

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/steps/defaults/frames.steps
+++ b/vividus-plugin-web-app/src/main/resources/steps/defaults/frames.steps
@@ -1,12 +1,3 @@
-Composite: When I switch to a frame by the xpath '$xpath'
-When I switch to frame located `xpath(<xpath>)`
-
-Composite: When I switch to a frame with the attribute '$attributeType'='$attributeValue'
-When I switch to frame located `xpath(.//*[(local-name()='frame' or local-name()='iframe') and @<attributeType>='<attributeValue>'])`
-
-Composite: When I switch to a frame number '$numberValue' with the attribute '$attributeType'='$attributeValue'
-When I switch to frame located `xpath((.//*[(local-name()='frame' or local-name()='iframe') and @<attributeType>='<attributeValue>'])[<numberValue>]):a`
-
 Composite: Then a frame with the attribute '$attributeType'='$attributeValue' exists
 Then number of elements found by `xpath(.//iframe[@<attributeType>='<attributeValue>'])` is = `1`
 

--- a/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
@@ -39,7 +39,7 @@ Then each element with locator `By.xpath(.//form)` has `2` child elements with l
 
 Scenario: Step verification When I hover a mouse over an element located '$locator'
 Given I am on a page with the URL 'https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onmousemove_over_enter'
-When I switch to a frame with the attribute 'id'='iframeResult'
+When I switch to frame located `By.id(iframeResult)`
 When I change context to an element by By.xpath(//div[contains(., 'onmouseover: Mouse over me!')])
 When I hover mouse over element located `By.xpath(self::*)`
 Then the text 'onmouseover: 1' exists
@@ -78,7 +78,7 @@ Then the text 'has been successfully uploaded' exists
 
 Scenario: Should not fail click step when element in Cross-Origin frame
 Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/frames.html'
-When I switch to a frame with the attribute 'id'='exampleCom'
+When I switch to frame located `By.id(exampleCom)`
 When I click on element located `By.xpath(//a[contains(text(), 'More')])`
 
 !-- Composites down there
@@ -185,7 +185,7 @@ Then a [ENABLED] element with the tag 'p' exists
 
 Scenario: Step verification When I hover a mouse over an element with the xpath '$xpath'
 Given I am on a page with the URL 'https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onmousemove_over_enter'
-When I switch to a frame with the attribute 'id'='iframeResult'
+When I switch to frame located `By.id(iframeResult)`
 When I change context to an element by By.xpath(//div[contains(., 'onmouseover: Mouse over me!')])
 When I hover a mouse over an element with the xpath 'self::*'
 Then the text 'onmouseover: 1' exists

--- a/vividus-tests/src/main/resources/story/integration/ImageStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ImageStepsTests.story
@@ -35,7 +35,7 @@ Then a [VISIBLE] image with the src '/w3css/img_avatar3.png' exists
 
 Scenario: Step verification Then an image with the src '$src' does not exist
 Given I am on a page with the URL 'https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_link_image'
-When I switch to a frame with the attribute 'id'='iframeResult'
+When I switch to frame located `By.id(iframeResult)`
 When I click on an image with the src 'logo_w3s.gif'
 Then an image with the src 'logo_w3s.gif' does not exist
 

--- a/vividus-tests/src/main/resources/story/integration/LinkStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/LinkStepsTests.story
@@ -98,19 +98,19 @@ Then a link with the URL '#' and tooltip 'Link title' does not exist
 
 Scenario: Step verification Then a link with the text '$text' and URL '$URL' and tooltip '$tooltip' does not exist
 Given I am on a page with the URL 'https://www.w3schools.com/html/tryit.asp?filename=tryhtml_links_title'
-When I switch to a frame with the attribute 'id'='iframeResult'
+When I switch to frame located `By.id(iframeResult)`
 Then a link with the text 'Visit our HTML Tutorial' and tooltip 'Go to W3Schools HTML section' exists
 When I click on a link with the text 'Visit our HTML Tutorial' and URL 'https://www.w3schools.com/html/'
 Then a link with the text 'Visit our HTML Tutorial' and URL 'https://www.w3schools.com/html/' and tooltip 'Go to W3Schools HTML section' does not exist
 
 Scenario: Step verification Then a link with the text '$text' and URL '$URL' and tooltip '$tooltip' exists
 Given I am on a page with the URL 'https://www.w3schools.com/html/tryit.asp?filename=tryhtml_links_title'
-When I switch to a frame with the attribute 'id'='iframeResult'
+When I switch to frame located `By.id(iframeResult)`
 Then a link with the text 'Visit our HTML Tutorial' and URL 'https://www.w3schools.com/html/' and tooltip 'Go to W3Schools HTML section' exists
 
 Scenario: Step verification Then a [$state] link with the text '$text' and URL '$URL' and tooltip '$tooltip' exists
 Given I am on a page with the URL 'https://www.w3schools.com/html/tryit.asp?filename=tryhtml_links_title'
-When I switch to a frame with the attribute 'id'='iframeResult'
+When I switch to frame located `By.id(iframeResult)`
 Then a [VISIBLE] link with the text 'Visit our HTML Tutorial' and URL 'https://www.w3schools.com/html/' and tooltip 'Go to W3Schools HTML section' exists
 
 Scenario: Step verification Then a [$state] link with text '$text' and URL containing '$URLpart' exists

--- a/vividus-tests/src/main/resources/story/integration/SetContextStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/SetContextStepsTests.story
@@ -49,42 +49,6 @@ When I switch to frame located `id(exampleCom)`
 When I click on element located `By.xpath(//a)`
 
 
-Scenario: Verify step: "When I switch to a frame by the xpath '$xpath'"
-When I refresh the page
-When I change context to element located `id(toRemove):a`
-When I perform javascript '
-document.querySelector('#toRemove').remove();
-return [];
-' and save result to the 'scenario' variable 'result'
-When I switch to a frame by the xpath '//iframe[@id='parent']'
-When I switch to a frame by the xpath '//frame[@id='exampleCom']'
-When I click on element located `By.xpath(//a)`
-
-
-Scenario: Verify step: "When I switch to a frame with the attribute '$attributeName'='$attributeValue'"
-When I refresh the page
-When I change context to element located `id(toRemove):a`
-When I perform javascript '
-document.querySelector('#toRemove').remove();
-return [];
-' and save result to the 'scenario' variable 'result'
-When I switch to a frame with the attribute 'id'='parent'
-When I switch to a frame with the attribute 'id'='exampleCom'
-When I click on element located `By.xpath(//a)`
-
-
-Scenario: Verify step: "When I switch to a frame number '$numberValue' with the attribute '$attributeType'='$attributeValue'"
-When I refresh the page
-When I change context to element located `id(toRemove):a`
-When I perform javascript '
-document.querySelector('#toRemove').remove();
-return [];
-' and save result to the 'scenario' variable 'result'
-When I switch to a frame number '1' with the attribute 'id'='parent'
-When I switch to a frame number '1' with the attribute 'id'='exampleCom'
-When I click on element located `By.xpath(//a)`
-
-
 Scenario: Verify step: "When I change context to the page" AND "When I change context to element located `$locator`"
 When I change context to element located `By.xpath(//body)`
 Then number of elements found by `By.xpath(html)` is equal to `0`


### PR DESCRIPTION
Removed steps (deprecated in `0.2.3`):
```gherkin
When I switch to a frame by the xpath '$xpath'
When I switch to a frame with the attribute '$attributeType'='$attributeValue'
When I switch to a frame number '$numberValue' with the attribute '$attributeType'='$attributeValue'
```
Replacement:
```gherkin
When I switch to frame located `$locator`
```