### PR TITLE
[plugin-web-app] Remove deprecated step uploading file

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/steps/defaults/composite.steps
+++ b/vividus-plugin-web-app/src/main/resources/steps/defaults/composite.steps
@@ -237,9 +237,6 @@ When I wait until element located `By.elementName(<elementName>)` contains text 
 Composite: Then an element with the name '$elementName' disappears in '$timeout' seconds
 Then element located `By.elementName(<elementName>)` disappears in '$timeout'
 
-Composite: When I select an element with the '$attributeType'='$attributeValue' and upload the file '$filePath'
-When I select element located `By.xpath(//*[@<attributeType>="<attributeValue>"])` and upload file `<filePath>`
-
 Composite: When I change context to an element by $locator
 When I change context to element located `<locator>`
 

--- a/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
@@ -196,12 +196,6 @@ Then an element by the xpath './/*[@class='context-menu-item context-menu-icon c
 When I perform right click on an element by the xpath './/*[@class='context-menu-one btn btn-neutral']'
 Then an element by the xpath './/*[@class='context-menu-item context-menu-icon context-menu-icon-edit']' exists
 
-Scenario: Step verification When I select an element with the '$attributeType'='$attributeValue' and upload the file '$filePath'
-Given I am on a page with the URL 'http://demo.guru99.com/test/upload/'
-When I select an element with the 'id'='uploadfile_0' and upload the file '/data/file_for_upload_step.png'
-When I click on element located `By.name(send)`
-Then the text 'has been successfully uploaded' exists
-
 Scenario: Step verification 'Then number of $state elements found by `$locator` is $comparisonRule `$quantity`'
 Given I am on a page with the URL '${vividus-test-site-url}'
 Then number of VISIBLE elements found by `tagName(img):a` is = `1`


### PR DESCRIPTION
Removed step (deprecated in 0.2.2):
```gherkin
When I select an element with the '$attributeType'='$attributeValue' and upload the file '$filePath'
```
Replacement:
```gherkin
When I select element located `$locator` and upload file `$filePath`
```