### PR TITLE
[plugin-web-app] Remove deprecated step checking page scroll position

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/steps/defaults/page.steps
+++ b/vividus-plugin-web-app/src/main/resources/steps/defaults/page.steps
@@ -1,2 +1,0 @@
-Composite: Then the page is scrolled to an element with the attribute '$attributeType'='$attributeValue'
-Then page is scrolled to element located `xpath(//*[@<attributeType>='<attributeValue>']):a`

--- a/vividus-tests/src/main/resources/story/integration/PageStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/PageStepsTests.story
@@ -11,13 +11,6 @@ When I wait until scroll is finished
 Then page is scrolled to element located `id(toClick)`
 
 
-Scenario: Verify step: 'Then the page is scrolled to an element with the attribute '$attributeType'='$attributeValue''
-When I refresh the page
-When I click on element located `By.id(anchor)`
-When I wait until scroll is finished
-Then the page is scrolled to an element with the attribute 'id'='toClick'
-
-
 Scenario: Verify step: When I open URL `$URL` in new window; Verify step: When I stop page loading
 Meta:
     @requirementId 1154; 1236


### PR DESCRIPTION
Removed step (deprecated in `0.2.3`):
```gherkin
Then the page is scrolled to an element with the attribute '$attributeType'='$attributeValue'
```
Replacement:
```gherkin
Then page is scrolled to element located `$locator`
```