### PR TITLE
[plugin-web-app] Remove deprecated step changing context to element

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/steps/defaults/composite.steps
+++ b/vividus-plugin-web-app/src/main/resources/steps/defaults/composite.steps
@@ -10,15 +10,15 @@ Then a link by By.linkUrlPart(<URLpart>) exists
 
 Composite: When I change context to an element by the xpath '$xpath'
 Priority: 1
-When I change context to an element by By.xpath(<xpath>)
+When I change context to element located `By.xpath(<xpath>)`
 
 Composite: When I change context to an element by the CSS selector '$cssSelector'
 Priority: 1
-When I change context to an element by By.cssSelector(<cssSelector>)
+When I change context to element located `By.cssSelector(<cssSelector>)`
 
 Composite: When I change context to an element with the name '$name'
 Priority: 1
-When I change context to an element by By.name(<name>)
+When I change context to element located `By.name(<name>)`
 
 Composite: Then the page title is '$pageTitle'
 Priority: 1
@@ -237,8 +237,6 @@ When I wait until element located `By.elementName(<elementName>)` contains text 
 Composite: Then an element with the name '$elementName' disappears in '$timeout' seconds
 Then element located `By.elementName(<elementName>)` disappears in '$timeout'
 
-Composite: When I change context to an element by $locator
-When I change context to element located `<locator>`
 
 Composite: When I wait '$duration' with '$pollingDuration' polling until an element located by $locator appears
 When I wait `<duration>` with `<pollingDuration>` polling until element located `<locator>` becomes VISIBLE

--- a/vividus-tests/src/main/resources/story/integration/ActionSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/ActionSteps.story
@@ -44,7 +44,7 @@ Then the text '${expectedText}' exists
 
 Scenario: Action verification CLICK_AND_HOLD
 Given I am on a page with the URL '${vividus-test-site-url}/mouseEvents.html'
-When I change context to an element by By.id(target)
+When I change context to element located `By.id(target)`
 Then the context element has the CSS property 'background-color'='rgba(255, 255, 255, 1)'
 When I execute sequence of actions:
 |type          |argument         |
@@ -53,7 +53,7 @@ Then the context element has the CSS property 'background-color'='rgba(255, 0, 0
 
 Scenario: Action verification CLICK_AND_HOLD with no argument
 Given I am on a page with the URL '${vividus-test-site-url}/mouseEvents.html'
-When I change context to an element by By.id(target)
+When I change context to element located `By.id(target)`
 Then the context element has the CSS property 'background-color'='rgba(255, 255, 255, 1)'
 When I execute sequence of actions:
 |type          |argument         |
@@ -63,7 +63,7 @@ Then the context element has the CSS property 'background-color'='rgba(255, 0, 0
 
 Scenario: Action verification RELEASE
 Given I am on a page with the URL '${vividus-test-site-url}/mouseEvents.html'
-When I change context to an element by By.id(target)
+When I change context to element located `By.id(target)`
 Then the context element has the CSS property 'background-color'='rgba(255, 255, 255, 1)'
 When I execute sequence of actions:
 |type          |argument         |
@@ -73,7 +73,7 @@ Then the context element has the CSS property 'background-color'='rgba(0, 128, 0
 
 Scenario: Action verification RELEASE with no argument
 Given I am on a page with the URL '${vividus-test-site-url}/mouseEvents.html'
-When I change context to an element by By.id(target)
+When I change context to element located `By.id(target)`
 Then the context element has the CSS property 'background-color'='rgba(255, 255, 255, 1)'
 When I execute sequence of actions:
 |type          |argument         |

--- a/vividus-tests/src/main/resources/story/integration/DragAndDropSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/DragAndDropSteps.story
@@ -4,7 +4,7 @@ Meta:
 Scenario: Step verification 'When I drag element located `$origin` and drop it at $location of element located `$target`'
 Given I am on a page with the URL 'https://4qp6vjp319.codesandbox.io/'
 When I wait until element located `By.xpath(//div[@id='root']/ul)` appears
-When I change context to an element by By.xpath(//div[@id='root']/ul)
+When I change context to element located `By.xpath(//div[@id='root']/ul)`
 Then the text matches 'item 0.*item 1.*item 2.*item 3.*'
 When I drag element located `By.xpath(//li[contains(., 'item 0')])` and drop it at top of element located `By.xpath(//li[contains(., 'item 3')])`
 Then the text matches 'item 1.*item 2.*item 0.*item 3.*'

--- a/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ElementStepsTests.story
@@ -40,7 +40,7 @@ Then each element with locator `By.xpath(.//form)` has `2` child elements with l
 Scenario: Step verification When I hover a mouse over an element located '$locator'
 Given I am on a page with the URL 'https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onmousemove_over_enter'
 When I switch to frame located `By.id(iframeResult)`
-When I change context to an element by By.xpath(//div[contains(., 'onmouseover: Mouse over me!')])
+When I change context to element located `By.xpath(//div[contains(., 'onmouseover: Mouse over me!')])`
 When I hover mouse over element located `By.xpath(self::*)`
 Then the text 'onmouseover: 1' exists
 
@@ -186,7 +186,7 @@ Then a [ENABLED] element with the tag 'p' exists
 Scenario: Step verification When I hover a mouse over an element with the xpath '$xpath'
 Given I am on a page with the URL 'https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onmousemove_over_enter'
 When I switch to frame located `By.id(iframeResult)`
-When I change context to an element by By.xpath(//div[contains(., 'onmouseover: Mouse over me!')])
+When I change context to element located `By.xpath(//div[contains(., 'onmouseover: Mouse over me!')])`
 When I hover a mouse over an element with the xpath 'self::*'
 Then the text 'onmouseover: 1' exists
 

--- a/vividus-tests/src/main/resources/story/integration/ImageStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ImageStepsTests.story
@@ -3,13 +3,13 @@ Meta:
 
 Scenario: Step verification When I hover a mouse over an image with the src '$src'
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 When I hover a mouse over an image with the src '/w3css/img_avatar3.png'
 Then an element by the xpath './/div[@class='textfade']' exists
 
 Scenario: Step verification When I hover a mouse over an image with the tooltip '$tooltipImage'
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 When I hover a mouse over an image with the tooltip 'Avatar'
 Then an element by the xpath './/div[@class='textfade']' exists
 
@@ -25,12 +25,12 @@ Then a link by By.xpath(//a[@href='#ElementId']) exists
 
 Scenario: Step verification Then an image with the src '$src' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then an image with the src '/w3css/img_avatar3.png' exists
 
 Scenario: Step verification Then a [$state] image with the src '$src' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then a [VISIBLE] image with the src '/w3css/img_avatar3.png' exists
 
 Scenario: Step verification Then an image with the src '$src' does not exist
@@ -41,7 +41,7 @@ Then an image with the src 'logo_w3s.gif' does not exist
 
 Scenario: Step verification Then an image with the src containing '$srcpart' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then an image with the src containing '3css/img_avatar3.png' exists
 
 Scenario: Step verification Then an image with the tooltip '$tooltip' and src containing '$srcpart' exists
@@ -54,20 +54,20 @@ Then an image with the src 'img/vividus.png' and tooltip 'Vividus Logo' exists
 
 Scenario: Step verification Then a [$state] image with the src '$imageSrc' and tooltip '$tooltip' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then a [VISIBLE] image with the src '/w3css/img_avatar3.png' and tooltip 'Avatar' exists
 
 Scenario: Step verification Then a [$state] image with the src containing '$srcpart' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then a [VISIBLE] image with the src containing '3css/img_avatar3.png' exists
 
 Scenario: Step verification Then a [$state] image with the tooltip '$tooltipImage' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then a [VISIBLE] image with the tooltip 'Avatar' exists
 
 Scenario: Step verification Then an image with the tooltip '$tooltipImage' exists
 Given I am on a page with the URL 'https://www.w3schools.com/howto/howto_css_image_overlay.asp'
-When I change context to an element by By.xpath(.//div[@class='containerfade'])
+When I change context to element located `By.xpath(.//div[@class='containerfade'])`
 Then an image with the tooltip 'Avatar' exists

--- a/vividus-tests/src/main/resources/story/integration/LinkStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/LinkStepsTests.story
@@ -3,7 +3,7 @@ Meta:
 
 Scenario: Step verification Then context contains list of link items with the text: $expectedLinkItems
 Given I am on a page with the URL 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link'
-When I change context to an element by By.cssSelector(.standard-table)
+When I change context to element located `By.cssSelector(.standard-table)`
 Then context contains list of link items with the text:
 |text                                                    |
 |RFC 8288, section 3: Link Serialisation in HTTP Headers |
@@ -11,7 +11,7 @@ Then context contains list of link items with the text:
 
 Scenario: Step verification Then context contains list of link items with the text and link: $expectedLinkItems
 Given I am on a page with the URL 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link'
-When I change context to an element by By.cssSelector(.standard-table)
+When I change context to element located `By.cssSelector(.standard-table)`
 Then context contains list of link items with the text and link:
 |text                                                    |link                                         |
 |RFC 8288, section 3: Link Serialisation in HTTP Headers |https://tools.ietf.org/html/rfc8288#section-3|
@@ -67,13 +67,13 @@ Then the page with the URL 'https://developer.mozilla.org/en-US/docs/MDN/About#C
 Scenario: Step verification Then a link with the text '$text' does not exist
 Given I am on a page with the URL 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover'
 Then a link with the text 'CSS: Cascading Style Sheets' exists
-When I change context to an element by By.cssSelector(.page-header)
+When I change context to element located `By.cssSelector(.page-header)`
 Then a link with the text 'CSS: Cascading Style Sheets' does not exist
 
 Scenario: Step verification Then a link with the text '$text' and URL '$URL' does not exist
 Given I am on a page with the URL 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover'
 Then a link with the text 'CSS: Cascading Style Sheets' and URL '/en-US/docs/Web/CSS' exists
-When I change context to an element by By.cssSelector(.page-header)
+When I change context to element located `By.cssSelector(.page-header)`
 Then a link with the text 'CSS: Cascading Style Sheets' and URL '/en-US/docs/Web/CSS' does not exist
 
 Scenario: Step verification: Then a link with the URL '$URL' and tooltip '$tooltip' exists

--- a/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
@@ -3,28 +3,28 @@ Meta:
 
 Scenario: Scroll RIGHT for element Verify step: When I scroll context to $scrollDirection edge
 Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/scrollableElements.html'
-When I change context to an element by By.id(scrollable)
+When I change context to element located `By.id(scrollable)`
 When I scroll context to RIGHT edge
-When I change context to an element by By.id(current-horizontal):a
+When I change context to element located `By.id(current-horizontal):a`
 Then the text matches '\d+'
 
 Scenario: Scroll LEFT for element Verify step: When I scroll context to $scrollDirection edge
-When I change context to an element by By.id(scrollable)
+When I change context to element located `By.id(scrollable)`
 When I scroll context to LEFT edge
-When I change context to an element by By.id(current-horizontal):a
+When I change context to element located `By.id(current-horizontal):a`
 Then the text matches '0'
 
 Scenario: Scroll BOTTOM for element Verify step: When I scroll context to $scrollDirection edge
-When I change context to an element by By.id(current-vertical):a
-When I change context to an element by By.id(scrollable)
+When I change context to element located `By.id(current-vertical):a`
+When I change context to element located `By.id(scrollable)`
 When I scroll context to BOTTOM edge
-When I change context to an element by By.id(current-vertical):a
+When I change context to element located `By.id(current-vertical):a`
 Then the text matches '\d+'
 
 Scenario: Scroll TOP for element Verify step: When I scroll context to $scrollDirection edge
-When I change context to an element by By.id(scrollable)
+When I change context to element located `By.id(scrollable)`
 When I scroll context to TOP edge
-When I change context to an element by By.id(current-vertical):a
+When I change context to element located `By.id(current-vertical):a`
 Then the text matches '0'
 
 Scenario: Verify step: When I scroll element located `$locator` into view
@@ -32,7 +32,7 @@ Meta:
     @requirementId 436
 When I refresh the page
 When I scroll element located `xpath(//a[text()="Contact"])` into view
-When I change context to an element by By.id(current-vertical):a
+When I change context to element located `By.id(current-vertical):a`
 Then the text matches '\d+'
 
 Scenario: Scroll BOTTOM for page Verify step: When I scroll context to $scrollDirection edge

--- a/vividus-tests/src/main/resources/story/system/ApplitoolsVisualStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/ApplitoolsVisualStepsTests.story
@@ -17,7 +17,7 @@ When I <action> baseline `full-page` in batch `<batchName>` with Applitools
 
 
 Scenario: Validation of step: 'When I $actionType baseline `$testName` in batch `$batchName` with Applitools' for context element
-When I change context to an element by <firstP>
+When I change context to element located `<firstP>`
 When I <action> baseline `context` in batch `<batchName>` with Applitools
 
 Scenario: Validation of step: 'When I run visual test with Applitools using:$applitoolsConfigurations' for full page with element cut
@@ -34,14 +34,14 @@ When I run visual test with Applitools using:
 
 
 Scenario: Validation of step: 'When I run visual test with Applitools using:$applitoolsConfigurations' for context element with element cut
-When I change context to an element by By.xpath(.//body)
+When I change context to element located `By.xpath(.//body)`
 When I run visual test with Applitools using:
 |baselineName        |batchName  |action  |elementsToIgnore|
 |context-element-cut |<batchName>|<action>|<firstP>        |
 
 
 Scenario: Validation of step: 'When I run visual test with Applitools using:$applitoolsConfigurations' for context element not in viewport with element cut
-When I change context to an element by By.xpath(.//p[last()])
+When I change context to element located `By.xpath(.//p[last()])`
 When I run visual test with Applitools using:
 |baselineName                     |batchName  |action  |elementsToIgnore   |
 |not-viewport-context-element-cut |<batchName>|<action>|By.cssSelector(img)|

--- a/vividus-tests/src/main/resources/story/system/VisualStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/VisualStepsTests.story
@@ -17,7 +17,7 @@ When I <action> baseline with `full-page`
 
 
 Scenario: Validation of step When I $actionType baseline with `$name` for context element
-When I change context to an element by <firstP>
+When I change context to element located `<firstP>`
 When I <action> baseline with `context`
 When I change context to the page
 
@@ -35,14 +35,14 @@ When I <action> baseline with `full-page-area-cut` ignoring:
 
 
 Scenario: Validation of step When I $actionType baseline with `$name` ignoring:$ignoredElements for context element with element cut
-When I change context to an element by By.xpath(.//body)
+When I change context to element located `By.xpath(.//body)`
 When I <action> baseline with `context-element-cut` ignoring:
 |ELEMENT         |
 |<firstP>  |
 
 
 Scenario: Validation of step When I $actionType baseline with `$name` ignoring:$ignoredElements for context element not in viewport with element cut
-When I change context to an element by By.xpath(.//p[last()])
+When I change context to element located `By.xpath(.//p[last()])`
 When I <action> baseline with `not-viewport-context-element-cut` ignoring:
 |ELEMENT                                                                                     |
 |By.cssSelector(img)|


### PR DESCRIPTION
Removed step (deprecated in `0.2.3`):
```gherkin
When I change context to an element by $locator
```
Replacement:
```gherkin
When I change context to element located `$locator`
```