### PR TITLE
[allure-adaptor] Make Allure link comparison null-safe

### DIFF
--- a/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/AllureStoryReporter.java
+++ b/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/AllureStoryReporter.java
@@ -22,6 +22,7 @@ import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -451,7 +452,7 @@ public class AllureStoryReporter extends ChainedStoryReporter implements IAllure
             String url = event.getUrl();
 
             boolean notExists = result.getLinks().stream()
-                                              .noneMatch(l -> l.getUrl().equals(url) && l.getName().equals(name));
+                    .noneMatch(l -> Objects.equals(l.getUrl(), url) && Objects.equals(l.getName(), name));
 
             if (notExists)
             {


### PR DESCRIPTION
Error:
```
2021-01-05 09:59:04,620 [batch-1-thread-1] ERROR com.google.common.eventbus.EventBus.default - Exception thrown by subscriber method onLinkPublish(org.vividus.reporter.event.LinkPublishEvent) on subscriber AllureStoryReporter[allureReportGenerator=org.vividus.bdd.report.allure.AllureReportGenerator@21848c8d,allureRunContext=org.vividus.bdd.report.allure.AllureRunContext@25c0aaf3,batchStorage=org.vividus.bdd.batch.BatchStorage@40b14c8f,bddRunContext=org.vividus.bdd.context.BddRunContext@5bfd43df,lifecycle=io.qameta.allure.AllureLifecycle@5e184cc9,testContext=org.vividus.testcontext.ThreadedTestContext@7e2fe2cb,verificationErrorAdapter=org.vividus.bdd.report.allure.adapter.VerificationErrorAdapter@34301cb5,delegates={VariableStoryReporter[bddVariableContext=org.vividus.bdd.context.BddVariableContext@19802836,delegates={StatusStoryReporter[status=Optional[PASSED],delegates={DelegatingStoryReporter[delegates={LoggingStoryReporter[TXT,org.vividus.bdd.log.LoggingPrintStream@7e416485],org.vividus.analytics.AnalyticsStoryReporter@59e0d521}]}]}]}] when dispatching event: org.vividus.reporter.event.LinkPublishEvent@1c29a36e
 java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "io.qameta.allure.model.Link.getUrl()" is null
	at org.vividus.bdd.report.allure.AllureStoryReporter.lambda$onLinkPublish$10(AllureStoryReporter.java:454) ~[vividus-allure-adaptor-0.2.15-SNAPSHOT.jar:0.2.15-SNAPSHOT]
	at java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1602) ~[?:?]
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127) ~[?:?]
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230) ~[?:?]
	at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.noneMatch(ReferencePipeline.java:538) ~[?:?]
	at org.vividus.bdd.report.allure.AllureStoryReporter.lambda$onLinkPublish$11(AllureStoryReporter.java:454) ~[vividus-allure-adaptor-0.2.15-SNAPSHOT.jar:0.2.15-SNAPSHOT]
	at io.qameta.allure.AllureLifecycle.updateTestCase(AllureLifecycle.java:400) ~[allure-java-commons-2.13.7.jar:2.13.7]
	at org.vividus.bdd.report.allure.AllureStoryReporter.onLinkPublish(AllureStoryReporter.java:448) ~[vividus-allure-adaptor-0.2.15-SNAPSHOT.jar:0.2.15-SNAPSHOT]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:564) ~[?:?]
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:87) ~[guava-30.1-jre.jar:?]
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:144) ~[guava-30.1-jre.jar:?]
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:72) ~[guava-30.1-jre.jar:?]
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30) ~[guava-30.1-jre.jar:?]
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:67) ~[guava-30.1-jre.jar:?]
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:108) ~[guava-30.1-jre.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:212) ~[guava-30.1-jre.jar:?]
	at org.vividus.ui.report.AbstractSessionLinkPublisher.lambda$publishSessionLink$0(AbstractSessionLinkPublisher.java:89) ~[vividus-extension-selenium-0.2.15-SNAPSHOT.jar:0.2.15-SNAPSHOT]
	at java.util.Optional.ifPresent(Optional.java:176) [?:?]
	at org.vividus.ui.report.AbstractSessionLinkPublisher.publishSessionLink(AbstractSessionLinkPublisher.java:89) [vividus-extension-selenium-0.2.15-SNAPSHOT.jar:0.2.15-SNAPSHOT]
	at org.vividus.ui.report.AbstractSessionLinkPublisher.publishSessionLinkAfterScenario(AbstractSessionLinkPublisher.java:68) [vividus-extension-selenium-0.2.15-SNAPSHOT.jar:0.2.15-SNAPSHOT]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:564) ~[?:?]
	at org.jbehave.core.steps.StepCreator$MethodInvoker.invoke(StepCreator.java:1008) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.steps.StepCreator$BeforeOrAfterStep.perform(StepCreator.java:715) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.steps.StepCreator$DelegatingStep.perform(StepCreator.java:680) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$FineSoFar.run(PerformableTree.java:390) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableSteps.perform(PerformableTree.java:1334) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.perform(PerformableTree.java:1211) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.performScenario(PerformableTree.java:1203) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$NormalPerformableScenario.perform(PerformableTree.java:1249) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableScenario.perform(PerformableTree.java:1105) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableStory.performScenarios(PerformableTree.java:992) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableStory.perform(PerformableTree.java:960) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree.performCancellable(PerformableTree.java:469) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.PerformableTree.perform(PerformableTree.java:436) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.StoryManager$EnqueuedStory.call(StoryManager.java:295) [jbehave-core-4.9.0-alpha.jar:?]
	at org.jbehave.core.embedder.StoryManager$EnqueuedStory.call(StoryManager.java:268) [jbehave-core-4.9.0-alpha.jar:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
	at java.lang.Thread.run(Thread.java:832) [?:?]
```