### PR TITLE
[allure-adaptor] Remove outdated placeholder for cloud test links

### DIFF
--- a/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/AllureStoryReporter.java
+++ b/vividus-allure-adaptor/src/main/java/org/vividus/bdd/report/allure/AllureStoryReporter.java
@@ -615,21 +615,9 @@ public class AllureStoryReporter extends ChainedStoryReporter implements IAllure
         }
 
         String id = step.getValue();
-        String testRunId = getTestRunId();
-        if (testRunId != null)
-        {
-            Link testRunLink = ResultsUtils.createTmsLink(testRunId).setName("Test run ID");
-            lifecycle.updateTestCase(id, result -> result.getLinks().add(testRunLink));
-        }
-
         lifecycle.stopTestCase(id);
         lifecycle.writeTestCase(id);
         switchToParent();
-    }
-
-    private String getTestRunId()
-    {
-        return null;
     }
 
     private StatusDetails getStatusDetailsFromThrowable(Throwable throwable)


### PR DESCRIPTION
The cloud test links are published using event-driven approach: #1216, #1249, #1263, #1265
The outdated placeholder is not used.