### PR TITLE
[analytics] Use non-encrypted tracking ID

### DIFF
--- a/vividus-analytics/src/main/resources/properties/defaults/default.properties
+++ b/vividus-analytics/src/main/resources/properties/defaults/default.properties
@@ -1,3 +1,3 @@
 analytics.enabled=false
-analytics.tracking-id=ENC(Lj5GBk5QNLpQYG1OcVNOMsu/EzEz2U4q)
+analytics.tracking-id=UA-167152972-1
 analytics.uri=https://www.google-analytics.com/collect


### PR DESCRIPTION
The default properties encrypted with the default password can't be decrypted when the custom encryption password is used, in other words it completely blocks usage of the custom password