### PR TITLE
[reporter] Configure Freemarker output as HTML

### DIFF
--- a/vividus-reporter/src/main/resources/org/vividus/reporter/spring.xml
+++ b/vividus-reporter/src/main/resources/org/vividus/reporter/spring.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
     default-lazy-init="true">
 
     <bean id="attachmentPublisher" class="org.vividus.reporter.event.AttachmentPublisher">
@@ -13,6 +16,9 @@
                         <constructor-arg index="0" value="org.vividus.reporter.event.AttachmentPublisher" />
                         <constructor-arg index="1" value="/" />
                     </bean>
+                </property>
+                <property name="outputFormat">
+                    <util:constant static-field="freemarker.core.HTMLOutputFormat.INSTANCE" />
                 </property>
             </bean>
         </property>


### PR DESCRIPTION
https://freemarker.apache.org/docs/dgui_misc_autoescaping.html

Before:
<img width="1259" alt="Screen Shot 2021-06-07 at 11 08 01 AM" src="https://user-images.githubusercontent.com/5081226/120981884-c765a200-c780-11eb-9af0-624d92d90cc7.png">

After:
<img width="1240" alt="Screen Shot 2021-06-07 at 11 06 49 AM" src="https://user-images.githubusercontent.com/5081226/120981913-ce8cb000-c780-11eb-83c9-634c6d0a39b6.png">
