### PR TITLE
[plugin-rest-api] Fix MIME-type detection for HTTP requests

### DIFF
--- a/vividus-plugin-rest-api/src/test/java/org/vividus/http/HttpClientInterceptorTests.java
+++ b/vividus-plugin-rest-api/src/test/java/org/vividus/http/HttpClientInterceptorTests.java
@@ -85,9 +85,8 @@ class HttpClientInterceptorTests
     void testHttpRequestIsAttachedSuccessfully() throws IOException
     {
         Header entityContentTypeHeader = mockContentTypeHeader();
-        Header[] headers = {entityContentTypeHeader};
         when(entityContentTypeHeader.getElements()[0].getParameters()).thenReturn(new NameValuePair[0]).getMock();
-        testHttpRequestIsAttachedSuccessfully(headers, entityContentTypeHeader);
+        testHttpRequestIsAttachedSuccessfully(new Header[] {entityContentTypeHeader}, entityContentTypeHeader);
     }
 
     @Test
@@ -104,7 +103,10 @@ class HttpClientInterceptorTests
         Header contentTypeHeader = mockContentTypeHeader();
         when(contentTypeHeader.getName()).thenReturn(contentTypeHeaderName);
         when(contentTypeHeader.getValue()).thenReturn(TEXT_PLAIN);
-        testHttpRequestIsAttachedSuccessfully(new Header[] { contentTypeHeader }, null);
+        var httpEntity = mock(HttpEntity.class);
+        testHttpRequestIsAttachedSuccessfully(contentTypeHeader, httpEntity);
+        verify(httpEntity).getContentLength();
+        verify(httpEntity).writeTo(any(ByteArrayOutputStream.class));
     }
 
     @Test
@@ -179,6 +181,13 @@ class HttpClientInterceptorTests
         HeaderElement headerElement = mock(HeaderElement.class);
         when(headerElement.getName()).thenReturn(TEXT_PLAIN);
         return when(mock(Header.class).getElements()).thenReturn(new HeaderElement[] { headerElement }).getMock();
+    }
+
+    private void testHttpRequestIsAttachedSuccessfully(Header contentTypeHeader, HttpEntity httpEntity)
+    {
+        HttpEntityEnclosingRequest httpRequest = mockHttpEntityEnclosingRequest(new Header[] { contentTypeHeader },
+                httpEntity);
+        testHttpRequestIsAttachedSuccessfully(httpRequest);
     }
 
     private void testHttpRequestIsAttachedSuccessfully(Header[] allRequestHeaders, Header entityContentTypeHeader)


### PR DESCRIPTION
Before:
<img width="1337" alt="Screen Shot 2021-06-07 at 11 55 42 AM" src="https://user-images.githubusercontent.com/5081226/120988548-5a093f80-c787-11eb-8036-9b2090ef1928.png">

After:
<img width="1332" alt="Screen Shot 2021-06-07 at 11 53 48 AM" src="https://user-images.githubusercontent.com/5081226/120988632-68eff200-c787-11eb-8835-5e354a9c6ea7.png">
