### PR TITLE
[plugin-db] Fix source JDBC url in queries statistic

### DIFF
--- a/vividus-plugin-db/src/test/java/org/vividus/bdd/steps/db/DatabaseStepsTests.java
+++ b/vividus-plugin-db/src/test/java/org/vividus/bdd/steps/db/DatabaseStepsTests.java
@@ -402,7 +402,7 @@ class DatabaseStepsTests
                             && 1 == statistics.getMatched()
                             && 0 == source.getNoPair()
                             && 0 == target.getNoPair()
-                            && DB_URL.equals(source.getUrl())
+                            && source.getUrl() == null
                             && DB_URL.equals(target.getUrl());
                 }), eq(QUERIES_STATISTICS));
     }


### PR DESCRIPTION
Affected steps:
```gherkin
Then `$data` matching rows using `$keys` from `$dbKey` is equal to data from:$table
When I wait for '$duration' duration retrying $retryTimes times while data from `$sqlQuery` executed against `$dbKey` is equal to data from:$table
```

Before:
<img width="1239" alt="Screen Shot 2021-06-07 at 3 03 51 PM" src="https://user-images.githubusercontent.com/5081226/121013553-a2355b80-c7a1-11eb-9f72-fac7cd284b0a.png">

After:
<img width="1241" alt="Screen Shot 2021-06-07 at 3 01 44 PM" src="https://user-images.githubusercontent.com/5081226/121013565-a95c6980-c7a1-11eb-9419-2643b6b288eb.png">
