### PR TITLE
[CI] Configure Codecov action to use token 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -97,6 +97,7 @@ jobs:
       if: matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 
     - name: Integration tests


### PR DESCRIPTION
This is a workaround for https://github.com/codecov/codecov-action/issues/330 (https://community.codecov.com/t/intermittent-unable-to-locate-build-via-github-actions-api/2936).
The error is:

```
->  Pinging Codecov
https://codecov.io/upload/v4?package=github-action-1.0.2&token=secret&branch=execute-sql-against-csv&commit=d6906de616f61371400cda154be88c4a61d45be2&build=914910056&build_url=http%3A%2F%2Fgithub.com%2Fvividus-framework%2Fvividus%2Factions%2Fruns%2F914910056&name=&tag=&slug=vividus-framework%2Fvividus&service=github-actions&flags=&pr=1697&job=Vividus%20CI&cmd_args=n,F,Q,Z,C
{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
404
==> Uploading to Codecov
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  226k  100   171  100  226k    895  1183k --:--:-- --:--:-- --:--:-- 1184k
    {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
Error: Codecov failed with the following error: The process '/usr/bin/bash' failed with exit code 1
```