### PR TITLE
[CI] Remove workaround for Codecov action issue

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -97,7 +97,6 @@ jobs:
       if: matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 
     - name: Integration tests


### PR DESCRIPTION
codecov/codecov-action#330

https://docs.codecov.io/docs/about-the-codecov-bash-uploader#upload-token:
> If you have a public project on TravisCI, CircleCI, AppVeyor, Azure Pipelines, or GitHub Actions an upload token is not required.