### PR TITLE
Do not consider Freemarker output as HTML for all attachments by default

### DIFF
--- a/vividus-plugin-db/src/main/resources/data-sources-statistics.ftl
+++ b/vividus-plugin-db/src/main/resources/data-sources-statistics.ftl
@@ -33,6 +33,7 @@
         }
     </style>
 
+    <#outputformat "HTML">
     <#assign left = statistics.left>
     <#assign right = statistics.right>
     <div class="panel-group" id="accordion">
@@ -114,6 +115,7 @@
                 </div>
         </div>
     </div>
+    </#outputformat>
 
     <script src="../../webjars/jquery/2.1.1/jquery.min.js"></script>
     <script src="../../webjars/bootstrap/3.3.6/js/bootstrap.min.js"></script>

--- a/vividus-reporter/src/main/resources/org/vividus/reporter/spring.xml
+++ b/vividus-reporter/src/main/resources/org/vividus/reporter/spring.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:util="http://www.springframework.org/schema/util"
-    xsi:schemaLocation="
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
     default-lazy-init="true">
 
     <bean id="attachmentPublisher" class="org.vividus.reporter.event.AttachmentPublisher">
@@ -16,9 +13,6 @@
                         <constructor-arg index="0" value="org.vividus.reporter.event.AttachmentPublisher" />
                         <constructor-arg index="1" value="/" />
                     </bean>
-                </property>
-                <property name="outputFormat">
-                    <util:constant static-field="freemarker.core.HTMLOutputFormat.INSTANCE" />
                 </property>
             </bean>
         </property>

--- a/vividus-reporter/src/main/resources/templates/maps-comparison-table.ftl
+++ b/vividus-reporter/src/main/resources/templates/maps-comparison-table.ftl
@@ -125,10 +125,10 @@
                     <#assign left = (cell.left)!"null">
                     <#assign right = (cell.right)!"null">
                     <td class="${class}">
-                        <span class="exceedable">${createCell(left)?no_esc}</span>
+                        <span class="exceedable">${createCell(left)}</span>
                     </td>
                     <td class="${class}">
-                        <span class="exceedable">${createCell(right)?no_esc}</span>
+                        <span class="exceedable">${createCell(right)}</span>
                     </td>
                     <#assign cellNumber++>
                 </#list>


### PR DESCRIPTION
HTML attachements for report may contain also: JS, CSS. Also they may include logic of constructing HTML using Freemarker functions. Moreover there are templates which are out of our control: `allure-jsonunit-2.14.0.jar!/tpl/diff.ftl`.
As result the default output format (HTML) can't be applied and should be disabled.