### PR TITLE
[util] Consider vividus config properties as strings

### DIFF
--- a/vividus-tests/src/main/resources/properties/suite/integration/suite.properties
+++ b/vividus-tests/src/main/resources/properties/suite/integration/suite.properties
@@ -28,3 +28,4 @@ ui.visual.ignored-elements=By.id(some_fake_id)
 # Check that property value can be non-string and it can be successfully assigned
 # and processed by configuration resolver and decryptor
 property=#{2 * 2}
+bdd.variables.global.property-with-int-value=#{2 + 2}

--- a/vividus-tests/src/main/resources/story/integration/VariableTests.story
+++ b/vividus-tests/src/main/resources/story/integration/VariableTests.story
@@ -152,3 +152,6 @@ Then `#{trim(${numbers})}` is equal to `12345`
 
 Scenario: Use environment variable as Vividus variable
 Then `${java}` is equal to `${JAVA_HOME}`
+
+Scenario: Compare variable with int value
+Then `${property-with-int-value}` is equal to `4`

--- a/vividus-util/src/main/java/org/vividus/util/property/PropertyParser.java
+++ b/vividus-util/src/main/java/org/vividus/util/property/PropertyParser.java
@@ -110,6 +110,6 @@ public class PropertyParser implements IPropertyParser
     private Map<String, String> filterProperties(Predicate<? super Entry<Object, Object>> filter)
     {
         return properties.entrySet().stream().filter(filter)
-                .collect(toMap(p -> (String) p.getKey(), p -> (String) p.getValue()));
+                .collect(toMap(p -> (String) p.getKey(), p -> p.getValue().toString()));
     }
 }

--- a/vividus-util/src/test/java/org/vividus/util/property/PropertyParserTests.java
+++ b/vividus-util/src/test/java/org/vividus/util/property/PropertyParserTests.java
@@ -44,6 +44,8 @@ class PropertyParserTests
     private static final String VAL_3 = "val3";
     private static final String PROP_3 = "prop3";
     private static final String OTHER_PROP3 = OTHER + DOT + PROP_3;
+    private static final String NUMBER_KEY = "number";
+    private static final String NUMBER_VALUE = "911";
 
     private PropertyParser parser;
     private Map<String, String> expectedPropertyValues;
@@ -59,14 +61,19 @@ class PropertyParserTests
         properties = new Properties();
         expectedPropertyValues.forEach((key, value) -> properties.put(PREFIX + key, value));
         properties.put(PREFIX + OTHER_PROP3, VAL_3);
+        properties.put(PREFIX + NUMBER_KEY, Integer.parseInt(NUMBER_VALUE));
         parser = new PropertyParser(properties);
     }
 
     @Test
     void testGetPropertiesByPrefix()
     {
-        Map<String, String> propertiesByPrefix = parser.getPropertiesByPrefix(PREFIX);
-        assertThat(propertiesByPrefix.entrySet(), equalTo(properties.entrySet()));
+        assertEquals(Map.of(
+            PREFIX + PROP_2, VAL_2,
+            PREFIX + PROP_1, VAL_1,
+            PREFIX + NUMBER_KEY, NUMBER_VALUE,
+            PREFIX + OTHER_PROP3, VAL_3
+        ), parser.getPropertiesByPrefix(PREFIX));
     }
 
     @Test
@@ -75,6 +82,7 @@ class PropertyParserTests
         Map<String, String> actualPropertyValues = parser.getPropertyValuesByPrefix(PREFIX);
         Map<String, String> expected = new HashMap<>(expectedPropertyValues);
         expected.put(OTHER_PROP3, VAL_3);
+        expected.put(NUMBER_KEY, NUMBER_VALUE);
         assertThat(actualPropertyValues.entrySet(), equalTo(expected.entrySet()));
     }
 
@@ -105,6 +113,7 @@ class PropertyParserTests
         Map<String, Object> expected = Map.of(
                 PROP_1, VAL_1,
                 PROP_2, VAL_2,
+                NUMBER_KEY, NUMBER_VALUE,
                 OTHER, Map.of(
                         PROP_3, VAL_3,
                         "other1", Map.of(


### PR DESCRIPTION
```
Caused by: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String (java.lang.Integer and java.lang.String are in module java.base of loader 'bootstrap')
        at org.vividus.util.property.PropertyParser.lambda$filterProperties$8(PropertyParser.java:113)
        at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:178)
        at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
        at org.vividus.util.property.PropertyParser.filterProperties(PropertyParser.java:113)
        at org.vividus.util.property.PropertyParser.getPropertiesByPrefix(PropertyParser.java:44)
        at org.vividus.util.property.PropertyParser.getPropertyValuesByPrefix(PropertyParser.java:50)
        at org.vividus.bdd.variable.VariablesFactory.init(VariablesFactory.java:55)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:567)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1912)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1854)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1782)
        ... 205 more
```