### PR TITLE
[plugin-browserstack] Increase network logs wait timeout from 40 to 50 seconds

### DIFF
--- a/vividus-plugin-browserstack/src/main/java/org/vividus/browserstack/BrowserStackAutomateClient.java
+++ b/vividus-plugin-browserstack/src/main/java/org/vividus/browserstack/BrowserStackAutomateClient.java
@@ -36,7 +36,7 @@ import org.vividus.util.wait.Waiter;
 public class BrowserStackAutomateClient extends BrowserStackClient
 {
     private static final int DEFAULT_RETRY = 5;
-    private static final int DEFAULT_SECONDS = 40;
+    private static final int DEFAULT_SECONDS = 50;
 
     private final Waiter waiter = new DurationBasedWaiter(
             new WaitMode(Duration.ofSeconds(DEFAULT_SECONDS), DEFAULT_RETRY));


### PR DESCRIPTION
It seems 40 seconds are not always enough: https://github.com/vividus-framework/vividus/pull/1907/checks?check_run_id=3432161214