### PR TITLE
[CI] Fix system tests broken by new SauceConnect

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -213,7 +213,7 @@ jobs:
                                                 -Pvividus.bdd.story-loader.batch-1.resource-include-patterns=ProxyStepsTests.story \
                                                 -Pvividus.selenium.grid.username=${SAUCELABS_USER} \
                                                 -Pvividus.selenium.grid.password=${SAUCELABS_KEY} \
-                                                -Pvividus.saucelabs.sauce-connect.command-line-arguments="--no-ssl-bump-domains example.com" \
+                                                -Pvividus.saucelabs.sauce-connect.command-line-arguments="--proxy-localhost --no-ssl-bump-domains example.com" \
                                                 -Pvividus.statistics.print-failures=true
         else
             echo No SAUCELABS_USER and/or SAUCELABS_KEY, SauceLabs integration tests will be skipped


### PR DESCRIPTION
https://changelog.saucelabs.com/en/sauce-connect-proxy-version-30JTvzO0F:

Sauce Connect Proxy Version 4.7.0
> “--proxy-localhost” boolean flag is added to support proxying upstream requests to localhost. This is no longer the default behavior