### PR TITLE
[vividus] Skip `ExamplesTable`-s loading while counting used steps

### DIFF
--- a/vividus/src/main/java/org/vividus/runner/BddStepsCounter.java
+++ b/vividus/src/main/java/org/vividus/runner/BddStepsCounter.java
@@ -38,9 +38,9 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.Keywords;
-import org.jbehave.core.model.Scenario;
-import org.jbehave.core.model.Story;
-import org.jbehave.core.parsers.StoryParser;
+import org.jbehave.core.model.ExamplesTable;
+import org.jbehave.core.model.ExamplesTableFactory;
+import org.jbehave.core.parsers.RegexStoryParser;
 import org.jbehave.core.steps.CandidateSteps;
 import org.jbehave.core.steps.InjectableStepsFactory;
 import org.jbehave.core.steps.StepCandidate;
@@ -55,7 +55,6 @@ public final class BddStepsCounter
     private static final String DEFAULT_STORY_LOCATION = "story";
     private static final String SPACE = " ";
     private static final String OCCURRENCES = "occurrence(s)";
-    private final List<String> stepList = new ArrayList<>();
     private final Set<StepCandidate> stepCandidates = new HashSet<>();
     private final Map<String, Integer> stepsWithStats = new HashMap<>();
     private final List<String> missedSteps = new ArrayList<>();
@@ -89,28 +88,33 @@ public final class BddStepsCounter
                 ? commandLine.getOptionValue(directoryOption.getOpt()) : DEFAULT_STORY_LOCATION;
         Configuration configuration = BeanFactory.getBean(Configuration.class);
 
-        fillStepList(configuration, storyLoader, pathFinder, storyLocation);
+        List<String> steps = collectSteps(configuration, storyLoader, pathFinder, storyLocation);
         fillStepCandidates();
-        fillStepsWithStats(configuration);
+        fillStepsWithStats(configuration, steps);
         printResults(commandLine, topOption, System.out);
     }
 
-    private void fillStepList(Configuration configuration, StoryLoader storyLoader, IPathFinder pathFinder,
+    private List<String> collectSteps(Configuration configuration, StoryLoader storyLoader, IPathFinder pathFinder,
             String storyLocation) throws IOException
     {
-        StoryParser storyParser = configuration.storyParser();
         Keywords keywords = configuration.keywords();
-        BatchResourceConfiguration batchResourceConfiguration = createResourceBatch(storyLocation);
-        for (String path : pathFinder.findPaths(batchResourceConfiguration))
+        RegexStoryParser storyParser = new RegexStoryParser(new ExamplesTableFactory(keywords, null, null)
         {
-            String storyString = storyLoader.loadResourceAsText(path);
-            Story story = storyParser.parseStory(storyString);
-            for (Scenario scenario : story.getScenarios())
+            @Override
+            public ExamplesTable createExamplesTable(String input)
             {
-                stepList.addAll(scenario.getSteps().stream().filter(step -> !step.startsWith(keywords.ignorable()))
-                        .collect(Collectors.toList()));
+                return ExamplesTable.EMPTY;
             }
-        }
+        });
+        BatchResourceConfiguration batchResourceConfiguration = createResourceBatch(storyLocation);
+        return pathFinder.findPaths(batchResourceConfiguration)
+                .stream()
+                .map(storyLoader::loadResourceAsText)
+                .map(storyParser::parseStory)
+                .flatMap(story -> story.getScenarios().stream())
+                .flatMap(scenario -> scenario.getSteps().stream())
+                .filter(step -> !step.startsWith(keywords.ignorable()))
+                .collect(Collectors.toList());
     }
 
     private BatchResourceConfiguration createResourceBatch(String storyLocation)
@@ -131,11 +135,11 @@ public final class BddStepsCounter
         }
     }
 
-    private void fillStepsWithStats(Configuration configuration)
+    private void fillStepsWithStats(Configuration configuration, List<String> steps)
     {
         Keywords keywords = configuration.keywords();
         String previousNonAndStep = null;
-        for (String stepValue : stepList)
+        for (String stepValue : steps)
         {
             String currentNonAndStep = null;
             if (stepValue.startsWith(keywords.and()))


### PR DESCRIPTION
Also this change will help to avoid problems happened in PR like #2015: https://github.com/vividus-framework/vividus/pull/2015/checks?check_run_id=3768388013:
```
> Task :vividus-tests:countSteps
2021-10-01 14:51:37,548 [main] INFO  org.vividus.report.MetadataLogger - 
  _   _______   _________  __  ______
 | | / /  _/ | / /  _/ _ \/ / / / __/
 | |/ // / | |/ // // // / /_/ /\ \  
 |___/___/ |___/___/____/\____/___/  
                                     

2021-10-01 14:51:37,639 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /defaults
2021-10-01 14:51:37,652 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /
2021-10-01 14:51:37,692 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /profile/web/headless/chrome
2021-10-01 14:51:37,695 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /suite/ui
2021-10-01 14:51:37,698 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /suite/additional
2021-10-01 14:51:37,700 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /suite/integration
2021-10-01 14:51:37,703 [main] INFO  org.vividus.configuration.ConfigurationResolver - Loading properties from /deprecated
Error: Exception in thread "main" java.lang.IllegalArgumentException: java.io.FileNotFoundException: /${examples-table-temporary-file} (No such file or directory)
	at org.vividus.bdd.StoryLoader.resourceAsStream(StoryLoader.java:61)
	at org.jbehave.core.io.LoadFromClasspath.loadResourceAsText(LoadFromClasspath.java:66)
	at org.vividus.bdd.StoryLoader.loadResourceAsText(StoryLoader.java:49)
	at org.jbehave.core.model.ExamplesTableFactory.createExamplesTable(ExamplesTableFactory.java:82)
	at org.jbehave.core.parsers.RegexStoryParser.parseExamplesTable(RegexStoryParser.java:337)
	at org.jbehave.core.parsers.RegexStoryParser.parseScenario(RegexStoryParser.java:298)
	at org.jbehave.core.parsers.RegexStoryParser.parseScenariosFrom(RegexStoryParser.java:275)
	at org.jbehave.core.parsers.RegexStoryParser.parseStory(RegexStoryParser.java:69)
	at org.jbehave.core.parsers.RegexStoryParser.parseStory(RegexStoryParser.java:53)
	at org.vividus.runner.BddStepsCounter.fillStepList(BddStepsCounter.java:107)
	at org.vividus.runner.BddStepsCounter.countSteps(BddStepsCounter.java:92)
	at org.vividus.runner.BddStepsCounter.main(BddStepsCounter.java:71)
Caused by: java.io.FileNotFoundException: /${examples-table-temporary-file} (No such file or directory)
	at java.base/java.io.FileInputStream.open0(Native Method)

	at java.base/java.io.FileInputStream.open(FileInputStream.java:211)
> Task :vividus-tests:countSteps FAILED
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:153)

	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:108)
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
	at java.base/sun.net.www.protocol.file.FileURLConnection.connect(FileURLConnection.java:86)

	at java.base/sun.net.www.protocol.file.FileURLConnection.getInputStream(FileURLConnection.java:189)
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
	at org.springframework.core.io.UrlResource.getInputStream(UrlResource.java:186)

	at org.vividus.bdd.StoryLoader.resourceAsStream(StoryLoader.java:57)
See https://docs.gradle.org/7.2/userguide/command_line_interface.html#sec:command_line_warnings
	... 11 more
```