### PR TITLE
Revert "Bump Allure from 2.14.0 to 2.15.0 (#1968)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ project.description = 'Vividus'
 
 ext {
     versions = [
-        allure:                 '2.15.0',
+        allure:                 '2.14.0',
         ashot:                  '1.5.4',
         commonsLang3:           '3.12.0',
         commonsText:            '1.9',


### PR DESCRIPTION
Fixes #2016

This reverts commit 1c0657f0f7dca7ef46a0e1d95b783d1995ad03c8.

Allure 2.15.0 relies on Tika 2.X which is incompatible with ReportPortal client 4.X.