### PR TITLE
[vividus] Handle special char `%` in printing failures table

### DIFF
--- a/vividus/src/main/java/org/vividus/report/MetadataLogger.java
+++ b/vividus/src/main/java/org/vividus/report/MetadataLogger.java
@@ -143,7 +143,7 @@ public final class MetadataLogger
         table.setPaddingLeftRight(1);
         table.setPaddingBottom(1);
         table.setTextAlignment(TextAlignment.LEFT);
-        message.format(table.render());
+        message.format("%s", table.render());
     }
 
     private static String wrap(String words)

--- a/vividus/src/test/java/org/vividus/report/MetadataLoggerTests.java
+++ b/vividus/src/test/java/org/vividus/report/MetadataLoggerTests.java
@@ -58,7 +58,8 @@ class MetadataLoggerTests
 {
     private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(MetadataLogger.class);
     private static final String FORMAT = "{}={}";
-    private static final String MESSAGE = "This is a very long message that should be wrapped to defined cell size";
+    private static final String MESSAGE = "This is a very long message that should be wrapped to defined cell size "
+            + "and with special char: %";
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -107,7 +108,7 @@ class MetadataLoggerTests
         + "\\│       \\│                                                    \\│           \\│                                                    \\│\\s+"
         + "├───────┼────────────────────────────────────────────────────┼───────────┼────────────────────────────────────────────────────┤\\s+"
         + "\\│ aaaaa \\│ This is a very long message that should be wrapped \\│ When I do \\│ This is a very long message that should be wrapped \\│\\s+"
-        + "\\│       \\│ to defined cell size                               \\│ \\|k\\|       \\│ to defined cell size                               \\│\\s+"
+        + "\\│       \\│ to defined cell size and with special char: %      \\│ \\|k\\|       \\│ to defined cell size and with special char: %      \\│\\s+"
         + "\\│       \\│                                                    \\│ \\|v\\|       \\│                                                    \\│\\s+"
         + "\\│       \\│                                                    \\│           \\│                                                    \\│\\s+"
         + "\\│ first \\│ verify                                             \\│ do        \\│ failure                                            \\│\\s+"


### PR DESCRIPTION
The error is:
```java
org.jbehave.core.failures.UUIDExceptionWrapper: org.jbehave.core.failures.BeforeOrAfterFailed: Method afterStories (annotated with @AfterStories in class org.vividus.bdd.steps.SetupSteps) failed: java.util.MissingFormatArgumentException: Format specifier '%e'
        at org.jbehave.core.steps.StepCreator$BeforeOrAfterStep.perform(StepCreator.java:749) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.jbehave.core.embedder.PerformableTree$FineSoFar.run(PerformableTree.java:387) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.jbehave.core.embedder.PerformableTree$PerformableSteps.perform(PerformableTree.java:1335) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.jbehave.core.embedder.PerformableTree.performBeforeOrAfterStories(PerformableTree.java:482) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.vividus.bdd.BatchedPerformableTree.performBeforeOrAfterStories(BatchedPerformableTree.java:34) ~[vividus-bdd-engine-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.jbehave.core.embedder.StoryManager.performStories(StoryManager.java:134) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.jbehave.core.embedder.StoryManager.runStories(StoryManager.java:111) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.jbehave.core.embedder.StoryManager.runStoriesAsPaths(StoryManager.java:98) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.vividus.bdd.BatchedEmbedder.lambda$runStoriesAsPaths$0(BatchedEmbedder.java:108) ~[vividus-bdd-engine-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.vividus.bdd.BatchedEmbedder.generateViewAfterExecution(BatchedEmbedder.java:131) [vividus-bdd-engine-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.vividus.bdd.BatchedEmbedder.runStoriesAsPaths(BatchedEmbedder.java:68) [vividus-bdd-engine-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.vividus.runner.GenericRunner.run(GenericRunner.java:107) [vividus-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59) [junit-4.13.1.jar:4.13.1]
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56) [junit-4.13.1.jar:4.13.1]
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.Suite.runChild(Suite.java:128) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.Suite.runChild(Suite.java:27) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) [junit-4.13.1.jar:4.13.1]
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413) [junit-4.13.1.jar:4.13.1]
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137) [junit-4.13.1.jar:4.13.1]
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115) [junit-4.13.1.jar:4.13.1]
        at org.junit.runner.JUnitCore.run(JUnitCore.java:105) [junit-4.13.1.jar:4.13.1]
        at org.junit.runner.JUnitCore.run(JUnitCore.java:94) [junit-4.13.1.jar:4.13.1]
        at org.vividus.runner.GenericRunner.main(GenericRunner.java:123) [vividus-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
Caused by: org.jbehave.core.failures.BeforeOrAfterFailed: Method afterStories (annotated with @AfterStories in class org.vividus.bdd.steps.SetupSteps) failed: java.util.MissingFormatArgumentException: Format specifier '%e'
        ... 46 more
Caused by: java.util.MissingFormatArgumentException: Format specifier '%e'
        at java.util.Formatter.format(Formatter.java:2688) ~[?:?]
        at java.util.Formatter.format(Formatter.java:2625) ~[?:?]
        at org.vividus.report.MetadataLogger.addFailureTable(MetadataLogger.java:146) ~[vividus-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.vividus.report.MetadataLogger.logExecutionStatistics(MetadataLogger.java:113) ~[vividus-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.vividus.report.MetadataLogger.logEnvironmentMetadata(MetadataLogger.java:87) ~[vividus-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at org.vividus.bdd.steps.SetupSteps.afterStories(SetupSteps.java:27) ~[vividus-0.3.11-SNAPSHOT.jar:0.3.11-SNAPSHOT]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
        at org.jbehave.core.steps.StepCreator$MethodInvoker.invoke(StepCreator.java:1026) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        at org.jbehave.core.steps.StepCreator$BeforeOrAfterStep.perform(StepCreator.java:745) ~[jbehave-core-5.0.0-alpha.13.jar:?]
        ... 45 more
```

The root cause is the exception containing `%e`:
```
...ip: 'fe80:0:0:0:1034:9bd0:e1b9:bccd%en0',...
```