### PR TITLE
[plugin-web-app] Fix NPE in web source code on-failure publisher

### DIFF
--- a/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/listener/WebSourceCodePublishingOnFailureListener.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/listener/WebSourceCodePublishingOnFailureListener.java
@@ -51,7 +51,7 @@ public class WebSourceCodePublishingOnFailureListener extends AbstractSourceCode
         {
             sourceCode = getElementSource(searchContext);
         }
-        else
+        else if (searchContext instanceof WebDriver)
         {
             sourceCode = ((WebDriver) searchContext).getPageSource();
         }

--- a/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/listener/WebSourceCodePublishingOnFailureListenerTests.java
+++ b/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/listener/WebSourceCodePublishingOnFailureListenerTests.java
@@ -42,11 +42,11 @@ import org.vividus.ui.context.IUiContext;
 class WebSourceCodePublishingOnFailureListenerTests
 {
     private static final String INNER_HTML = "innerHTML";
-    private static final TestLogger LOGGER =
-        TestLoggerFactory.getTestLogger(WebSourceCodePublishingOnFailureListener.class);
-    @Mock private IUiContext uiContext;
 
+    @Mock private IUiContext uiContext;
     @InjectMocks private WebSourceCodePublishingOnFailureListener listener;
+
+    private final TestLogger logger = TestLoggerFactory.getTestLogger(WebSourceCodePublishingOnFailureListener.class);
 
     @Test
     void shouldReturnWholePageForDriverContext()
@@ -75,6 +75,13 @@ class WebSourceCodePublishingOnFailureListenerTests
         when(uiContext.getSearchContext()).thenReturn(webElement);
         when(webElement.getAttribute(INNER_HTML)).thenThrow(StaleElementReferenceException.class);
         assertEquals(Optional.empty(), listener.getSourceCode());
-        assertEquals(LOGGER.getLoggingEvents(), List.of(debug("Unable to get sources of the stale element")));
+        assertEquals(logger.getLoggingEvents(), List.of(debug("Unable to get sources of the stale element")));
+    }
+
+    @Test
+    void shouldReturnEmptyValueForNullSearchContext()
+    {
+        when(uiContext.getSearchContext()).thenReturn(null);
+        assertEquals(Optional.empty(), listener.getSourceCode());
     }
 }


### PR DESCRIPTION
The NPE is thrwon when search context is `null`:
```
java.lang.NullPointerException: null
	at org.vividus.ui.web.listener.WebSourceCodePublishingOnFailureListener.getSourceCode(WebSourceCodePublishingOnFailureListener.java:56) ~[vividus-plugin-web-app-0.3.11.jar:0.3.11]
	at org.vividus.ui.listener.AbstractSourceCodePublishingOnFailureListener.onAssertionFailure(AbstractSourceCodePublishingOnFailureListener.java:49) ~[vividus-extension-selenium-0.3.11.jar:0.3.11]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:88) ~[guava-31.0.1-jre.jar:?]
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:145) ~[guava-31.0.1-jre.jar:?]
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:73) [guava-31.0.1-jre.jar:?]
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31) [guava-31.0.1-jre.jar:?]
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:68) [guava-31.0.1-jre.jar:?]
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:109) [guava-31.0.1-jre.jar:?]
	at com.google.common.eventbus.EventBus.post(EventBus.java:267) [guava-31.0.1-jre.jar:?]
	at org.vividus.softassert.SoftAssert.recordAssertionError(SoftAssert.java:364) [vividus-soft-assert-0.3.11.jar:0.3.11]
	at org.vividus.softassert.SoftAssert.recordAssertion(SoftAssert.java:339) [vividus-soft-assert-0.3.11.jar:0.3.11]
	at org.vividus.softassert.SoftAssert.recordAssertion(SoftAssert.java:266) [vividus-soft-assert-0.3.11.jar:0.3.11]
	at org.vividus.softassert.SoftAssert.recordFailedAssertion(SoftAssert.java:247) [vividus-soft-assert-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.ui.validation.BaseValidations.runValidatingSearchContext(BaseValidations.java:236) [vividus-extension-selenium-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.ui.validation.BaseValidations.assertIfElementExists(BaseValidations.java:165) [vividus-extension-selenium-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.ui.validation.BaseValidations.assertIfElementExists(BaseValidations.java:127) [vividus-extension-selenium-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.ui.web.FieldSteps.findElement(FieldSteps.java:199) [vividus-plugin-web-app-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.ui.web.FieldSteps.enterTextInField(FieldSteps.java:140) [vividus-plugin-web-app-0.3.11.jar:0.3.11]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
	at org.jbehave.core.steps.StepCreator$ParametrisedStep.perform(StepCreator.java:861) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.steps.StepCreator$ReportingAbstractStep.perform(StepCreator.java:686) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$FineSoFar.run(PerformableTree.java:387) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$FineSoFar.run(PerformableTree.java:397) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.vividus.bdd.steps.SubSteps.executeStep(SubSteps.java:77) [vividus-bdd-engine-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.SubSteps.execute(SubSteps.java:62) [vividus-bdd-engine-0.3.11.jar:0.3.11]
	at org.vividus.bdd.steps.ExecutableSteps.performAllStepsIfConditionIsTrue(ExecutableSteps.java:77) [vividus-0.3.11.jar:0.3.11]
	at jdk.internal.reflect.GeneratedMethodAccessor68.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
	at org.jbehave.core.steps.StepCreator$ParametrisedStep.perform(StepCreator.java:861) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.steps.StepCreator$ReportingAbstractStep.perform(StepCreator.java:686) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$FineSoFar.run(PerformableTree.java:387) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableSteps.perform(PerformableTree.java:1335) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.perform(PerformableTree.java:1214) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.performRestartableSteps(PerformableTree.java:1193) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.performScenario(PerformableTree.java:1205) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$ExamplePerformableScenario.perform(PerformableTree.java:1273) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableScenario.perform(PerformableTree.java:1103) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableStory.performScenarios(PerformableTree.java:997) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableStory.perform(PerformableTree.java:964) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree.performCancellable(PerformableTree.java:471) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.PerformableTree.perform(PerformableTree.java:438) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.StoryManager$EnqueuedStory.call(StoryManager.java:299) [jbehave-core-5.0.0-alpha.13.jar:?]
	at org.jbehave.core.embedder.StoryManager$EnqueuedStory.call(StoryManager.java:272) [jbehave-core-5.0.0-alpha.13.jar:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:835) [?:?]
```