### PR TITLE
[plugin-mobile-app] Deprecate web view switching by index

### DIFF
--- a/docs/modules/plugins/pages/plugin-mobile-app.adoc
+++ b/docs/modules/plugins/pages/plugin-mobile-app.adoc
@@ -408,6 +408,9 @@ Then the avatar icon is displayed with the uploaded image
 
 === Switch to Web view by index
 
+[WARNING]
+This step is deprecated and will be removed in VIVIDUS 0.5.0. The replacement is <<_switch_to_web_view_by_name>>.
+
 Switches context to a web view by the index, it starts from 1. {web-view-info}
 
 [source,gherkin]

--- a/vividus-plugin-mobile-app/src/main/java/org/vividus/bdd/mobileapp/steps/SetContextSteps.java
+++ b/vividus-plugin-mobile-app/src/main/java/org/vividus/bdd/mobileapp/steps/SetContextSteps.java
@@ -59,10 +59,15 @@ public class SetContextSteps
     /**
      * Switches context to a web view by the index, it starts from 1
      * @param index index of web view
+     * @deprecated Use step:
+     * When I switch to web view with name that $comparisonRule `$value`
      */
+    @Deprecated(since = "0.5.0", forRemoval = true)
     @When("I switch to web view with index `$index`")
     public void switchToWebViewByIndex(int index)
     {
+        LOGGER.warn("This step is deprecated and will be removed in VIVIDUS 0.5.0. The replacement is "
+                + "\"When I switch to web view with name that $comparisonRule `$value`\"");
         performOnWebViews(webViews ->
         {
             int webViewIndex = index - 1;

--- a/vividus-plugin-mobile-app/src/test/java/org/vividus/bdd/mobileapp/steps/SetContextStepsTests.java
+++ b/vividus-plugin-mobile-app/src/test/java/org/vividus/bdd/mobileapp/steps/SetContextStepsTests.java
@@ -17,6 +17,7 @@
 package org.vividus.bdd.mobileapp.steps;
 
 import static com.github.valfirst.slf4jtest.LoggingEvent.info;
+import static com.github.valfirst.slf4jtest.LoggingEvent.warn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Set;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
 import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import com.github.valfirst.slf4jtest.TestLoggerFactoryExtension;
@@ -50,6 +52,9 @@ class SetContextStepsTests
 {
     private static final String WEB_VIEW_MAIN = "WEBVIEW_MAIN";
     private static final String WEB_VIEWS_FOUND = "Web views found: {}";
+    private static final LoggingEvent DEPRECATION_NOTICE = warn(
+            "This step is deprecated and will be removed in VIVIDUS 0.5.0. The replacement is "
+            + "\"When I switch to web view with name that $comparisonRule `$value`\"");
 
     @Mock private IWebDriverProvider webDriverProvider;
     @Mock private ISoftAssert softAssert;
@@ -71,6 +76,7 @@ class SetContextStepsTests
         assertThat(logger.getLoggingEvents(), is(empty()));
     }
 
+    @SuppressWarnings("removal")
     @Test
     void shouldSwitchToWebViewByIndex()
     {
@@ -83,10 +89,12 @@ class SetContextStepsTests
         verify(contextAware).context(WEB_VIEW_MAIN);
         verifyNoMoreInteractions(softAssert, contextAware, webDriverProvider);
         assertThat(logger.getLoggingEvents(), is(List.of(
+                DEPRECATION_NOTICE,
                 info(WEB_VIEWS_FOUND, Set.of(WEB_VIEW_MAIN).toString()),
                 info("Switching to '{}' web view found by the index {}", WEB_VIEW_MAIN, 1))));
     }
 
+    @SuppressWarnings("removal")
     @Test
     void shouldNotSwitchToWebViewByIndexIfWebViewCollectionIsEmpty()
     {
@@ -97,9 +105,10 @@ class SetContextStepsTests
 
         verify(softAssert).recordFailedAssertion("No web views found");
         verifyNoMoreInteractions(softAssert, contextAware, webDriverProvider);
-        assertThat(logger.getLoggingEvents(), is(empty()));
+        assertThat(logger.getLoggingEvents(), is(List.of(DEPRECATION_NOTICE)));
     }
 
+    @SuppressWarnings("removal")
     @ValueSource(ints = { 2, -2 })
     @ParameterizedTest
     void shouldNotSwitchToWebViewByIndexIfWebViewWithIndexDoesNotExist(int webViewIndex)
@@ -112,7 +121,9 @@ class SetContextStepsTests
 
         verify(softAssert).recordFailedAssertion(String.format("Web view with index %s does not exist", webViewIndex));
         verifyNoMoreInteractions(softAssert, contextAware, webDriverProvider);
-        assertThat(logger.getLoggingEvents(), is(List.of(info(WEB_VIEWS_FOUND, Set.of(WEB_VIEW_MAIN).toString()))));
+        assertThat(logger.getLoggingEvents(), is(List.of(
+                DEPRECATION_NOTICE,
+                info(WEB_VIEWS_FOUND, Set.of(WEB_VIEW_MAIN).toString()))));
     }
 
     @Test


### PR DESCRIPTION
The order of web views returned by Appium is not reliable.
 - For Android platform the web views are retrieved by parsing UNIX socket names from /proc/net/unix.
 - For iOS platform the web views are considered as separate processes within the active application.

Sorting the web view by Inode number for android or PID for iOS doesn't seem logical for end users and as practice shows the order is not guaranteed.