### PR TITLE
[http-client] Restore default key factory behaviour

### DIFF
--- a/vividus-http-client/src/main/java/org/vividus/http/keystore/KeyStoreFactory.java
+++ b/vividus-http-client/src/main/java/org/vividus/http/keystore/KeyStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.vividus.util.ResourceUtils;
@@ -38,7 +39,7 @@ public class KeyStoreFactory implements IKeyStoreFactory
             try
             {
                 String keyStorePath = keyStoreOptions.getPath();
-                if (keyStorePath != null)
+                if (StringUtils.isNotBlank(keyStorePath))
                 {
                     String keyStorePassword = keyStoreOptions.getPassword();
                     if (keyStorePassword == null)

--- a/vividus-http-client/src/test/java/org/vividus/http/keystore/KeyStoreFactoryTests.java
+++ b/vividus-http-client/src/test/java/org/vividus/http/keystore/KeyStoreFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,9 @@ import java.security.cert.X509Certificate;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class KeyStoreFactoryTests
 {
@@ -69,10 +72,12 @@ class KeyStoreFactoryTests
                 exception.getMessage());
     }
 
-    @Test
-    void testGetKeyStoreEmptyPath()
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = "  ")
+    void testGetKeyStoreBlankPath(String path)
     {
-        KeyStoreFactory keyStoreFactory = createKeyStoreFactory(null, null);
+        KeyStoreFactory keyStoreFactory = createKeyStoreFactory(path, null);
         Optional<KeyStore> optionalkeyStore = keyStoreFactory.getKeyStore();
         assertFalse(optionalkeyStore.isPresent());
     }


### PR DESCRIPTION
```
Exception in thread "main" org.vividus.jira.JiraConfigurationException: java.lang.IllegalStateException: java.io.EOFException
        at org.vividus.jira.JiraClientProvider.getClient(JiraClientProvider.java:169)
        at org.vividus.jira.JiraClientProvider.getByFirst(JiraClientProvider.java:157)
        at org.vividus.jira.JiraClientProvider.getClientByProjectKey(JiraClientProvider.java:131)
        at org.vividus.jira.JiraClientProvider.getByProjectKey(JiraClientProvider.java:120)
        at org.vividus.jira.JiraFacade.lambda$getProject$0(JiraFacade.java:77)
        at org.vividus.jira.JiraFacade.getJiraEntity(JiraFacade.java:96)
        at org.vividus.jira.JiraFacade.getProject(JiraFacade.java:77)
        at org.vividus.zephyr.facade.ZephyrFacade.prepareConfiguration(ZephyrFacade.java:81)
        at org.vividus.zephyr.exporter.ZephyrExporter.exportResults(ZephyrExporter.java:71)
        at org.vividus.zephyr.VividusToZephyrExporterApplication.main(VividusToZephyrExporterApplication.java:55)
Caused by: java.lang.IllegalStateException: java.io.EOFException
        at org.vividus.http.keystore.KeyStoreFactory$1.initialize(KeyStoreFactory.java:60)
        at org.vividus.http.keystore.KeyStoreFactory$1.initialize(KeyStoreFactory.java:34)
        at org.apache.commons.lang3.concurrent.LazyInitializer.get(LazyInitializer.java:106)
        at org.vividus.http.keystore.KeyStoreFactory.getKeyStore(KeyStoreFactory.java:75)
        at org.vividus.http.client.HttpClientFactory.createSslContext(HttpClientFactory.java:117)
        at org.vividus.http.client.HttpClientFactory.buildHttpClient(HttpClientFactory.java:72)
        at org.vividus.jira.JiraClientProvider$1.load(JiraClientProvider.java:60)
        at org.vividus.jira.JiraClientProvider$1.load(JiraClientProvider.java:51)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3533)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2282)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2159)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
        at com.google.common.cache.LocalCache.get(LocalCache.java:3966)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3989)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4950)
        at org.vividus.jira.JiraClientProvider.getClient(JiraClientProvider.java:165)
        ... 9 more
Caused by: java.io.EOFException
        at java.base/java.io.DataInputStream.readInt(DataInputStream.java:398)
        at java.base/sun.security.provider.JavaKeyStore.engineLoad(JavaKeyStore.java:680)
        at java.base/sun.security.util.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:220)
        at java.base/java.security.KeyStore.load(KeyStore.java:1472)
        at org.vividus.http.keystore.KeyStoreFactory$1.initialize(KeyStoreFactory.java:52)
        ... 24 more


```