### PR TITLE
[plugin-mobile-app] Handle the exception if status bar height from session details is null

### DIFF
--- a/vividus-plugin-mobile-app/src/main/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManager.java
+++ b/vividus-plugin-mobile-app/src/main/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManager.java
@@ -141,7 +141,7 @@ public class MobileAppWebDriverManager extends GenericWebDriverManager
         Long statBarHeight = getStatBarHeightUnsafely();
         if (statBarHeight == null)
         {
-            throw new IllegalArgumentException("Unable to receive status bar height. Received value is null.");
+            throw new IllegalStateException("Unable to receive status bar height. Received value is null.");
         }
         return statBarHeight.intValue();
     }

--- a/vividus-plugin-mobile-app/src/main/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManager.java
+++ b/vividus-plugin-mobile-app/src/main/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,21 +72,26 @@ public class MobileAppWebDriverManager extends GenericWebDriverManager
         }
         if (isIOSNativeApp())
         {
+            Number statBarHeight;
             try
             {
-                return getStatBarHeight();
+                statBarHeight = getStatBarHeightUnsafely();
             }
             catch (WebDriverException e)
             {
                 // Handling SauceLabs error:
                 // org.openqa.selenium.WebDriverException:
                 // failed serving request GET https://production-sushiboat.default/wd/hub/session/XXXX
-
+                statBarHeight = null;
+            }
+            if (null == statBarHeight)
+            {
                 // Appium 1.21.0 or higher is required
                 Map<String, ?> deviceScreenInfo = javascriptActions.executeScript("mobile:deviceScreenInfo");
                 Map<String, ?> statusBarSize = (Map<String, ?>) deviceScreenInfo.get("statusBarSize");
-                return ((Number) statusBarSize.get(HEIGHT)).intValue();
+                statBarHeight = (Number) statusBarSize.get(HEIGHT);
             }
+            return statBarHeight.intValue();
         }
         return getAndroidStatusBar();
     }
@@ -108,7 +113,7 @@ public class MobileAppWebDriverManager extends GenericWebDriverManager
             // The workaround is for Android TV. It is not clear if any of the Android TVs could have a status bar
             // at all, but the session capabilities contains `statBarHeight`, and to be on the safe side fall-back code
             // was added to get the status bar height in case of exception.
-            return getStatBarHeight();
+            return getStatBarHeightSafely();
         }
     }
 
@@ -131,9 +136,18 @@ public class MobileAppWebDriverManager extends GenericWebDriverManager
         }
     }
 
-    private int getStatBarHeight()
+    private int getStatBarHeightSafely()
     {
-        Long statBarHeight = getSessionDetail("statBarHeight");
+        Long statBarHeight = getStatBarHeightUnsafely();
+        if (statBarHeight == null)
+        {
+            throw new IllegalArgumentException("Unable to receive status bar height. Received value is null.");
+        }
         return statBarHeight.intValue();
+    }
+
+    private Long getStatBarHeightUnsafely()
+    {
+        return getSessionDetail("statBarHeight");
     }
 }

--- a/vividus-plugin-mobile-app/src/main/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManager.java
+++ b/vividus-plugin-mobile-app/src/main/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManager.java
@@ -29,6 +29,7 @@ import javax.imageio.ImageIO;
 
 import com.google.common.base.Suppliers;
 
+import org.apache.commons.lang3.Validate;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriverException;
@@ -139,10 +140,7 @@ public class MobileAppWebDriverManager extends GenericWebDriverManager
     private int getStatBarHeightSafely()
     {
         Long statBarHeight = getStatBarHeightUnsafely();
-        if (statBarHeight == null)
-        {
-            throw new IllegalStateException("Unable to receive status bar height. Received value is null.");
-        }
+        Validate.validState(statBarHeight != null, "Unable to receive status bar height. Received value is null");
         return statBarHeight.intValue();
     }
 

--- a/vividus-plugin-mobile-app/src/test/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManagerTests.java
+++ b/vividus-plugin-mobile-app/src/test/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.withSettings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.imageio.ImageIO;
@@ -61,6 +62,9 @@ class MobileAppWebDriverManagerTests
     private static final String GET_SESSION_COMMAND = "getSession";
     private static final String STAT_BAR_HEIGHT = "statBarHeight";
     private static final String HEIGHT = "height";
+    private static final String MOBILE_DEVICE_SCREEN_INFO_JS = "mobile:deviceScreenInfo";
+    private static final Map<String, Object> STATUS_BAR_SIZE =
+        Map.of("statusBarSize", Map.of("width", 375, HEIGHT, 44), "scale", 3);
 
     private static final byte[] IMAGE = new byte[] { (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A,
             0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
@@ -121,11 +125,38 @@ class MobileAppWebDriverManagerTests
         when(webDriverProvider.getUnwrapped(ExecutesMethod.class)).thenReturn(executingMethodDriver);
         when(executingMethodDriver.execute(GET_SESSION_COMMAND)).thenThrow(new WebDriverException(
                 "failed serving request GET https://production-sushiboat.default/wd/hub/session/XXXX"));
-        when(javascriptActions.executeScript("mobile:deviceScreenInfo")).thenReturn(Map.of(
-                "statusBarSize", Map.of("width", 375, HEIGHT, 44),
-                "scale", 3
-        ));
+        when(javascriptActions.executeScript(MOBILE_DEVICE_SCREEN_INFO_JS)).thenReturn(STATUS_BAR_SIZE);
         assertEquals(44, driverManager.getStatusBarSize());
+    }
+
+    @Test
+    void shouldPerformJsRequestForStatBarHeightWhenSessionDetailsStatBarHeightIsNullForIos()
+    {
+        mockCapabilities(MobilePlatform.IOS);
+        ExecutesMethod executingMethodDriver = mock(ExecutesMethod.class);
+        when(webDriverProvider.getUnwrapped(ExecutesMethod.class)).thenReturn(executingMethodDriver);
+
+        Response response = new Response();
+        response.setValue(Collections.EMPTY_MAP);
+        when(executingMethodDriver.execute(GET_SESSION_COMMAND)).thenReturn(response);
+        when(javascriptActions.executeScript(MOBILE_DEVICE_SCREEN_INFO_JS)).thenReturn(STATUS_BAR_SIZE);
+        assertEquals(44, driverManager.getStatusBarSize());
+    }
+
+    @Test
+    void shouldThrowAnErrorWhenSessionDetailsStatBarHeightIsNullForAndroid()
+    {
+        mockCapabilities(MobilePlatform.ANDROID);
+        when(webDriverProvider.getUnwrapped(HasAndroidDeviceDetails.class)).thenThrow(new WebDriverException("Ooops!"));
+        ExecutesMethod executingMethodDriver = mock(ExecutesMethod.class);
+
+        when(webDriverProvider.getUnwrapped(ExecutesMethod.class)).thenReturn(executingMethodDriver);
+        Response response = new Response();
+        response.setValue(Collections.EMPTY_MAP);
+
+        when(executingMethodDriver.execute(GET_SESSION_COMMAND)).thenReturn(response);
+        Exception exception = assertThrows(IllegalArgumentException.class, driverManager::getStatusBarSize);
+        assertEquals("Unable to receive status bar height. Received value is null.", exception.getMessage());
     }
 
     @Test

--- a/vividus-plugin-mobile-app/src/test/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManagerTests.java
+++ b/vividus-plugin-mobile-app/src/test/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManagerTests.java
@@ -155,7 +155,7 @@ class MobileAppWebDriverManagerTests
         response.setValue(Collections.EMPTY_MAP);
 
         when(executingMethodDriver.execute(GET_SESSION_COMMAND)).thenReturn(response);
-        Exception exception = assertThrows(IllegalArgumentException.class, driverManager::getStatusBarSize);
+        var exception = assertThrows(IllegalStateException.class, driverManager::getStatusBarSize);
         assertEquals("Unable to receive status bar height. Received value is null.", exception.getMessage());
     }
 

--- a/vividus-plugin-mobile-app/src/test/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManagerTests.java
+++ b/vividus-plugin-mobile-app/src/test/java/org/vividus/selenium/mobileapp/MobileAppWebDriverManagerTests.java
@@ -156,7 +156,7 @@ class MobileAppWebDriverManagerTests
 
         when(executingMethodDriver.execute(GET_SESSION_COMMAND)).thenReturn(response);
         var exception = assertThrows(IllegalStateException.class, driverManager::getStatusBarSize);
-        assertEquals("Unable to receive status bar height. Received value is null.", exception.getMessage());
+        assertEquals("Unable to receive status bar height. Received value is null", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION

Received exception in [CI example](https://github.com/vividus-framework/vividus/runs/4689829224?check_suite_focus=true#step:21:2124)