### PR TITLE
[tests] Add wait step in MobileApp QR code scan step integration test

### DIFF
--- a/vividus-tests/src/main/resources/data/tables/system/mobile_app/locators/android.table
+++ b/vividus-tests/src/main/resources/data/tables/system/mobile_app/locators/android.table
@@ -12,3 +12,4 @@
 |carouselViewXpath          |//android.widget.TextView[@text='Carousel']          |
 |swipeableAreaXpath         |//android.widget.HorizontalScrollView                |
 |textFieldValueAttribute    |text                                                 |
+|scrollableMenuXpath        |//android.widget.ScrollView                          |

--- a/vividus-tests/src/main/resources/data/tables/system/mobile_app/locators/ios.table
+++ b/vividus-tests/src/main/resources/data/tables/system/mobile_app/locators/ios.table
@@ -13,3 +13,4 @@
 |swipeableAreaXpath         |(//XCUIElementTypeScrollView)[2]                       |
 |textFieldValueAttribute    |value                                                  |
 |keyboardLocator            |xpath(//XCUIElementTypeKeyboard)                       |
+|scrollableMenuXpath        |//XCUIElementTypeScrollView                            |

--- a/vividus-tests/src/main/resources/story/system/mobile_app/MobileAppStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/mobile_app/MobileAppStepsTests.story
@@ -280,6 +280,7 @@ Meta:
     @requirementId 2112
 When I tap on element located `accessibilityId(menuToggler)`
 When I tap on element located `xpath(<menuQrCodeXpath>)`
+When I wait until element located `xpath(<scrollableMenuXpath>)` disappears
 When I scan barcode from screen and save result to scenario variable `qrCodeLink`
 Then `${qrCodeLink}` is = `https://github.com/vividus-framework/vividus`
 


### PR DESCRIPTION
[Error example ](https://github.com/vividus-framework/vividus/runs/4700109279?check_suite_focus=true#step:25:1973)
Reason - sometimes QR scan is started before menu is disappeared 
![c7d66db216f005c4](https://user-images.githubusercontent.com/27370665/148069414-4d431668-f0f7-48f9-8333-6f78191fdff0.png)
