### PR TITLE
[CI] Avoid using PowerShell on Windows platform

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
-    
+
     env:
       TEST_APP_VERSION: 0.2.0
 
@@ -110,6 +110,7 @@ jobs:
         fail_ci_if_error: true
 
     - name: VIVIDUS tasks validation
+      shell: bash
       run: |
          ./gradlew validateKnownIssues printSteps countSteps -x testVividusInitialization  -p vividus-tests --project-prop 'vividus.bdd.variables.global.iterationLimit=3' --project-prop 'vividus.bdd.variables.global.target-platform=ios'
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -116,9 +116,25 @@ jobs:
 
 
     - name: Integration tests
-      if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'windows-latest'
+      if: matrix.platform == 'ubuntu-latest'
       run: |
-        ./gradlew :vividus-tests:debugStories --project-prop 'vividus.configuration.environments=integration' --project-prop 'vividus.allure.history-directory=output/history/integration-tests' --project-prop 'vividus.allure.executor.name="Github Actions (Vividus)"' --project-prop 'vividus.allure.executor.type=github' --project-prop 'vividus.allure.executor.url=https://github.com/vividus-framework/vividus/actions' --project-prop 'vividus.allure.executor.build-order=${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.build-name="Integration Tests ${GITHUB_RUN_ID}"' --project-prop 'vividus.allure.executor.build-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.report-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.report-name="Integration tests report"' --no-daemon
+        ./gradlew :vividus-tests:debugStories -Pvividus.configuration.environments=integration \
+                                              -Pvividus.allure.history-directory=output/history/integration-tests \
+                                              -Pvividus.allure.executor.name="Github Actions (Vividus)" \
+                                              -Pvividus.allure.executor.type=github \
+                                              -Pvividus.allure.executor.url=https://github.com/vividus-framework/vividus/actions \
+                                              -Pvividus.allure.executor.build-order=${GITHUB_RUN_ID} \
+                                              -Pvividus.allure.executor.build-name="Integration Tests ${GITHUB_RUN_ID}" \
+                                              -Pvividus.allure.executor.build-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID} \
+                                              -Pvividus.allure.executor.report-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID} \
+                                              -Pvividus.allure.executor.report-name="Integration tests report" \
+                                              --no-daemon
+
+    - name: Integration tests
+      if: matrix.platform == 'windows-latest'
+      shell: cmd
+      run: |
+        gradlew.bat :vividus-tests:debugStories --project-prop 'vividus.configuration.environments=integration' --project-prop 'vividus.allure.history-directory=output/history/integration-tests' --project-prop 'vividus.allure.executor.name="Github Actions (Vividus)"' --project-prop 'vividus.allure.executor.type=github' --project-prop 'vividus.allure.executor.url=https://github.com/vividus-framework/vividus/actions' --project-prop 'vividus.allure.executor.build-order=${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.build-name="Integration Tests ${GITHUB_RUN_ID}"' --project-prop 'vividus.allure.executor.build-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.report-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.report-name="Integration tests report"' --no-daemon
 
     - name: Publish integration tests report
       if: (matrix.platform == 'ubuntu-latest' || matrix.platform == 'windows-latest') && always()


### PR DESCRIPTION
Reason: PowerShell (default shell for Windows platform - https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/) doesn't fail the step in case if command is failed (this is expected default behavior - https://github.community/t/multiline-commands-on-windows-do-not-fail-if-individual-commands-fail/16753).