### PR TITLE
[tests] Fix execution of integration tests on Windows

### DIFF
--- a/vividus-tests/src/main/resources/story/ui/ScreenshotTakingStepsTests.story
+++ b/vividus-tests/src/main/resources/story/ui/ScreenshotTakingStepsTests.story
@@ -7,11 +7,11 @@ When I execute steps:
 
 
 Scenario: Verify screenshot taking steps
-When I initialize the scenario variable `numberOfScreenshots` with value `#{evalGroovy(def files = java.nio.file.Path.of('${screenshot-directory}').toFile()?.listFiles(); return files?.length?:0)}`
+When I initialize the scenario variable `numberOfScreenshots` with value `#{evalGroovy(def files = java.nio.file.Path.of($/${screenshot-directory}/$).toFile()?.listFiles(); return files?.length?:0)}`
 When I execute steps:
 |step           |
 |<stepUnderTest>|
-Then `1` is = `#{evalGroovy(return java.nio.file.Path.of('${screenshot-directory}').toFile().listFiles().length - ${numberOfScreenshots})}`
+Then `1` is = `#{evalGroovy(return java.nio.file.Path.of($/${screenshot-directory}/$).toFile().listFiles().length - ${numberOfScreenshots})}`
 
 Examples:
 |stepUnderTest                                                                                              |                                                                                  |


### PR DESCRIPTION
Paths on Windows contain backslash \ which is an escape character for Groovy single-quoted strings, it causes errors like:
```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Script1.groovy: 1: Unexpected character: '\'' @ line 1, column 35.
   def files = java.nio.file.Path.of('D:\a\vividus\vividus\vividus-tests\output/screenshots').toFile()?.listFiles(); return files?.length?:0
                                     ^

1 error
```

The solution is to use dollar slashy string to avoid the necessity to escape backslashes and/or forward slashes