### PR TITLE
[vividus] Switch from `Java Faker` to its fork `Data Faker`

### DIFF
--- a/vividus/build.gradle
+++ b/vividus/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation(group: 'com.google.guava', name: 'guava', version: versions.guava)
     implementation(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.137')
     implementation(group: 'org.apache.commons', name: 'commons-jexl3', version: '3.2.1')
-    implementation(group: 'com.github.javafaker', name: 'javafaker', version: '1.0.2')
+    implementation(group: 'net.datafaker', name: 'datafaker', version: '1.0.0')
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: versions.junit)
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')

--- a/vividus/src/main/java/org/vividus/expression/StringsExpressionProcessor.java
+++ b/vividus/src/main/java/org/vividus/expression/StringsExpressionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import java.util.zip.GZIPOutputStream;
 
 import javax.inject.Named;
 
-import com.github.javafaker.Faker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -40,6 +39,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.vividus.util.ILocationProvider;
 import org.vividus.util.ResourceUtils;
+
+import net.datafaker.Faker;
 
 @Named
 public class StringsExpressionProcessor extends DelegatingExpressionProcessor<String>


### PR DESCRIPTION
It seems [`Java Faker`](https://github.com/DiUS/java-faker) project is not actively maintained, while [`Data Faker`](https://github.com/datafaker-net/datafaker) project demonstrates a good start, see https://github.com/DiUS/java-faker/issues/681#issuecomment-1003178496.