### PR TITLE
[CI] Remove workaround for BrowserStack desktop system tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -499,8 +499,7 @@ jobs:
                                                   -Pvividus.selenium.grid.username=${BROWSERSTACK_USER} \
                                                   -Pvividus.selenium.grid.password=${BROWSERSTACK_KEY} \
                                                   -Pvividus.selenium.grid.capabilities.bstack\:options.projectName=Vividus \
-                                                  -Pvividus.selenium.grid.capabilities.bstack\:options.buildName="Vividus BrowserStack Integration Tests" \
-                                                  -Pvividus.selenium.grid.capabilities.browserVersion=latest
+                                                  -Pvividus.selenium.grid.capabilities.bstack\:options.buildName="Vividus BrowserStack Integration Tests"
           done
         else
             echo No BROWSERSTACK_USER and/or BROWSERSTACK_KEY, Browserstack integration tests will be skipped


### PR DESCRIPTION
BrowserStack reports the issue is fixed:
> I would like to share that our engineering team has deployed a fix and you should no longer be facing this issue.