### PR TITLE
Deprecate plugin-specific properties configuring Azure environment

### DIFF
--- a/docs/modules/plugins/partials/azure-profile-and-subscription.adoc
+++ b/docs/modules/plugins/partials/azure-profile-and-subscription.adoc
@@ -6,6 +6,8 @@ could be optionally specified using either global property `azure.environment`
 `azure.{azure-service-name}.environment`. The plugin-specific property takes
 precedence over the global one. The default value is `AZURE`.
 
+WARNING: The plugin-specific property `azure.{azure-service-name}.environment` is deprecated and will be removed in VIVIDUS 0.5.0. The global property must be used.
+
 The supported environments are only:
 
 - `AZURE`


### PR DESCRIPTION
There are actually 4 different, hosted clouds called Microsoft Azure. There’s the Public Azure Cloud and there are also separate Azure clouds for US Government, Germany, and China. There is no reason to use different types of clouds within one eco-system, thus there is no reason to provide the ability to use plugins for different clouds within single test execution (https://docs.microsoft.com/en-us/graph/deployments).