### PR TITLE
Fix logging libraries conflict

### DIFF
--- a/vividus-plugin-web-app-to-rest-api/build.gradle
+++ b/vividus-plugin-web-app-to-rest-api/build.gradle
@@ -11,7 +11,9 @@ dependencies {
 
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'com.github.crawler-commons', name: 'crawler-commons', version: '1.2')
-    implementation(group: 'de.hs-heilbronn.mi', name: 'crawler4j-with-sleepycat', version: '4.9.0')
+    implementation(group: 'de.hs-heilbronn.mi', name: 'crawler4j-with-sleepycat', version: '4.9.0') {
+        exclude module: 'log4j-slf4j-impl'
+    }
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: versions.junit)
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html:
1. log4j-slf4j-impl should be used with SLF4J 1.7.x releases or older.
2. log4j-slf4j18-impl should be used with SLF4J 1.8.x releases or newer.

Fixes #2803