### PR TITLE
[docs] Fix formatting of configuration properties usage warning

### DIFF
--- a/docs/modules/ROOT/pages/tests-configuration.adoc
+++ b/docs/modules/ROOT/pages/tests-configuration.adoc
@@ -9,8 +9,8 @@ VIVIDUS configuration includes the following parts: profiles, environments and s
 Properties prefixed with `_configuration._` should be specified in the following locations only:
 
 * The system properties.
-* The `*configuration.properties*` file.
-* The `*overriding.properties*` file.
+* The `_configuration.properties_` file.
+* The `_overriding.properties_` file.
 ====
 
 === Suites

--- a/docs/modules/ROOT/pages/tests-configuration.adoc
+++ b/docs/modules/ROOT/pages/tests-configuration.adoc
@@ -13,7 +13,6 @@ Properties prefixed with `*configuration.*` could be specified in the following 
 * The `*overriding.properties*` file.
 ====
 
-
 === Suites
 
 The property `configuration.suites` defines the suites set. It is a comma separated set of suite file addresses:

--- a/docs/modules/ROOT/pages/tests-configuration.adoc
+++ b/docs/modules/ROOT/pages/tests-configuration.adoc
@@ -6,7 +6,7 @@ VIVIDUS configuration includes the following parts: profiles, environments and s
 
 [WARNING]
 ====
-Properties prefixed with `*configuration.*` could be specified in the following locations only:
+Properties prefixed with `_configuration._` should be specified in the following locations only:
 
 * The system properties.
 * The `*configuration.properties*` file.

--- a/docs/modules/ROOT/pages/tests-configuration.adoc
+++ b/docs/modules/ROOT/pages/tests-configuration.adoc
@@ -6,11 +6,11 @@ VIVIDUS configuration includes the following parts: profiles, environments and s
 
 [WARNING]
 ====
-Properties prefixed with `_configuration._` should be specified in the following locations only:
+Properties prefixed with `*configuration.*` should be specified in the following locations only:
 
 * The system properties.
-* The `_configuration.properties_` file.
-* The `_overriding.properties_` file.
+* The `*configuration.properties*` file.
+* The `*overriding.properties*` file.
 ====
 
 === Suites

--- a/docs/modules/ROOT/pages/tests-configuration.adoc
+++ b/docs/modules/ROOT/pages/tests-configuration.adoc
@@ -6,11 +6,13 @@ VIVIDUS configuration includes the following parts: profiles, environments and s
 
 [WARNING]
 ====
-Properties prefixed with `configuration.` could be specified in the following locations only:
+Properties prefixed with `*configuration.*` could be specified in the following locations only:
+
 * The system properties.
-* The `configuration.properties` file.
-* The `overriding.properties` file.
+* The `*configuration.properties*` file.
+* The `*overriding.properties*` file.
 ====
+
 
 === Suites
 


### PR DESCRIPTION
<img width="820" alt="image" src="https://user-images.githubusercontent.com/17816729/171399140-4e66a4c1-3707-476f-abda-ddb1211eada9.png">
