### PR TITLE
[vividus-plugin-rest-api] Add attachment with archive entries in case step failure

### DIFF
--- a/vividus-plugin-rest-api/src/main/resources/archive-entries-result-table.ftl
+++ b/vividus-plugin-rest-api/src/main/resources/archive-entries-result-table.ftl
@@ -1,0 +1,56 @@
+<#ftl strip_whitespace=true>
+
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Archive entries</title>
+    <link rel="stylesheet" href="../../webjars/bootstrap/3.3.6/css/bootstrap.min.css"/>
+</head>
+<body>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            counter-reset: entryCounter;
+        }
+        table th {
+            text-align: center;
+            font-family: Arial, Helvetica, sans-serif;
+        }
+        table tbody tr:before {
+            counter-increment: entryCounter;
+            content: counter(entryCounter);
+            display: table-cell;
+            vertical-align: middle;
+            text-align: center;
+        }
+    </style>
+
+    <#if entryNames?has_content>
+      <table class="table table-hover table-bordered table-condensed fixedHeader">
+         <thead>
+            <tr>
+                <th>
+                    #
+                </th>
+                <th>
+                    Name
+                </th>
+            </tr>
+         </thead>
+         <tbody>
+            <#list entryNames as entry>
+                <tr>
+                    <td>
+                        ${entry}
+                    </td>
+                </tr>
+            </#list>
+         </tbody>
+      </table>
+    <#else>
+      There are no files in the archive
+    </#if>
+</body>
+</html>

--- a/vividus-plugin-rest-api/src/test/java/org/vividus/archive/steps/ArchiveStepsTests.java
+++ b/vividus-plugin-rest-api/src/test/java/org/vividus/archive/steps/ArchiveStepsTests.java
@@ -21,12 +21,15 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.vividus.steps.StringComparisonRule.CONTAINS;
 import static org.vividus.steps.StringComparisonRule.DOES_NOT_CONTAIN;
 import static org.vividus.steps.StringComparisonRule.IS_EQUAL_TO;
 import static org.vividus.steps.StringComparisonRule.MATCHES;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,7 @@ import org.vividus.context.VariableContext;
 import org.vividus.model.ArchiveVariable;
 import org.vividus.model.NamedEntry;
 import org.vividus.model.OutputFormat;
+import org.vividus.reporter.event.IAttachmentPublisher;
 import org.vividus.softassert.SoftAssert;
 import org.vividus.steps.DataWrapper;
 import org.vividus.steps.StringComparisonRule;
@@ -51,9 +55,13 @@ class ArchiveStepsTests
     private static final String FILE_JSON = "file.json";
     private static final String IMAGE_PNG = "images/image.png";
     private static final String DUMMY = "dummy";
-
+    private static final String MATHES_PATTERN = ".+\\.png";
+    private static final String CONTAINS_ENTRY_WITH_NAME = "The archive contains entry with name ";
+    private static final String CONTAINS_ENTRY_WITH_RULE = "The archive contains entry matching the "
+            + "comparison rule '%s' with name pattern '%s'";
     @Mock private SoftAssert softAssert;
     @Mock private VariableContext variableContext;
+    @Mock private IAttachmentPublisher attachmentPublisher;
 
     @InjectMocks  private ArchiveSteps archiveSteps;
 
@@ -91,45 +99,128 @@ class ArchiveStepsTests
     @Test
     void testVerifyArchiveContainsEntries()
     {
-        Set<String> archiveEntries = Set.of(IMAGE_PNG, FILE_JSON);
-        String message = "The archive contains entry with name ";
+        Set<String> archiveEntries = createArchiveEntries();
         archiveSteps.verifyArchiveContainsEntries(createArchiveData(), List.of(
                 createEntry(FILE_JSON, null),
                 createEntry(IMAGE_PNG, null),
                 createEntry(DUMMY, null)
         ));
-        verify(softAssert).assertThat(eq(message + FILE_JSON), eq(archiveEntries),
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + FILE_JSON), eq(archiveEntries),
                 argThat(e -> e.matches(archiveEntries)));
-        verify(softAssert).assertThat(eq(message + IMAGE_PNG), eq(archiveEntries),
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + IMAGE_PNG), eq(archiveEntries),
                 argThat(e -> e.matches(archiveEntries)));
-        verify(softAssert).assertThat(eq(message + DUMMY), eq(archiveEntries),
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + DUMMY), eq(archiveEntries),
                 argThat(e -> !e.matches(archiveEntries)));
         verifyNoMoreInteractions(softAssert);
+        verifyPublishAttachment(archiveEntries);
+        verifyNoMoreInteractions(attachmentPublisher);
+    }
+
+    @Test
+    void testVerifyArchiveContainsEntriesIsPassed()
+    {
+        Set<String> archiveEntries = createArchiveEntries();
+        when(softAssert.assertThat(eq(CONTAINS_ENTRY_WITH_NAME + IMAGE_PNG), eq(archiveEntries),
+                argThat(e -> e.matches(archiveEntries)))).thenReturn(true);
+        when(softAssert.assertThat(eq(CONTAINS_ENTRY_WITH_NAME + FILE_JSON), eq(archiveEntries),
+                argThat(e -> e.matches(archiveEntries)))).thenReturn(true);
+        archiveSteps.verifyArchiveContainsEntries(createArchiveData(), List.of(
+                createEntry(FILE_JSON, null),
+                createEntry(IMAGE_PNG, null)
+        ));
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + FILE_JSON), eq(archiveEntries),
+                argThat(e -> e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + IMAGE_PNG), eq(archiveEntries),
+                argThat(e -> e.matches(archiveEntries)));
+        verifyNoMoreInteractions(softAssert);
+        verifyNoInteractions(attachmentPublisher);
+    }
+
+    @Test
+    void testVerifyArchiveContainsEntriesIsFailled()
+    {
+        Set<String> archiveEntries = createArchiveEntries();
+        when(softAssert.assertThat(eq(CONTAINS_ENTRY_WITH_NAME + IMAGE_PNG), eq(archiveEntries),
+                argThat(e -> e.matches(archiveEntries)))).thenReturn(true);
+        when(softAssert.assertThat(eq(CONTAINS_ENTRY_WITH_NAME + DUMMY), eq(archiveEntries),
+                argThat(e -> !e.matches(archiveEntries)))).thenReturn(false);
+        archiveSteps.verifyArchiveContainsEntries(createArchiveData(), List.of(
+                createEntry(DUMMY, null),
+                createEntry(IMAGE_PNG, null)
+        ));
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + DUMMY), eq(archiveEntries),
+                argThat(e -> !e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(CONTAINS_ENTRY_WITH_NAME + IMAGE_PNG), eq(archiveEntries),
+                argThat(e -> e.matches(archiveEntries)));
+        verifyNoMoreInteractions(softAssert);
+        verifyPublishAttachment(archiveEntries);
+        verifyNoMoreInteractions(attachmentPublisher);
+    }
+
+    @Test
+    void testVerifyArchiveContainsEntriesWithUserRulesIsFailed()
+    {
+        Set<String> archiveEntries = createArchiveEntries();
+        when(softAssert.assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, DUMMY)),
+                eq(archiveEntries), argThat(e -> !e.matches(archiveEntries)))).thenReturn(false);
+        when(softAssert.assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, MATHES_PATTERN)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)))).thenReturn(true);
+        archiveSteps.verifyArchiveContainsEntries(createArchiveData(), List.of(
+                createEntry(DUMMY, MATCHES),
+                createEntry(MATHES_PATTERN, MATCHES)
+        ));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, DUMMY)),
+                eq(archiveEntries), argThat(e -> !e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, MATHES_PATTERN)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)));
+        verifyNoMoreInteractions(softAssert);
+        verifyPublishAttachment(archiveEntries);
+        verifyNoMoreInteractions(attachmentPublisher);
+    }
+
+    @Test
+    void testVerifyArchiveContainsEntriesWithUserRulesIsPassed()
+    {
+        Set<String> archiveEntries = createArchiveEntries();
+        when(softAssert.assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, MATHES_PATTERN)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)))).thenReturn(true);
+        archiveSteps.verifyArchiveContainsEntries(createArchiveData(), List.of(
+                createEntry(MATHES_PATTERN, MATCHES)
+        ));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, MATHES_PATTERN)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)));
+        verifyNoMoreInteractions(softAssert);
+        verifyNoInteractions(attachmentPublisher);
     }
 
     @Test
     void testVerifyArchiveContainsEntriesWithUserRules()
     {
-        String matchesPattern = ".+\\.png";
         String containsPattern = "file";
-
-        Set<String> archiveEntries = Set.of(IMAGE_PNG, FILE_JSON);
-        String message = "The archive contains entry matching the comparison rule '%s' with name pattern '%s'";
+        Set<String> archiveEntries = createArchiveEntries();
         archiveSteps.verifyArchiveContainsEntries(createArchiveData(), List.of(
-                createEntry(matchesPattern, MATCHES),
+                createEntry(MATHES_PATTERN, MATCHES),
                 createEntry(containsPattern, CONTAINS),
                 createEntry(DUMMY, IS_EQUAL_TO),
                 createEntry(DUMMY, DOES_NOT_CONTAIN)
         ));
-        verify(softAssert).assertThat(eq(String.format(message, MATCHES, matchesPattern)), eq(archiveEntries),
-                argThat(e -> e.matches(archiveEntries)));
-        verify(softAssert).assertThat(eq(String.format(message, CONTAINS, containsPattern)), eq(archiveEntries),
-                argThat(e -> e.matches(archiveEntries)));
-        verify(softAssert).assertThat(eq(String.format(message, IS_EQUAL_TO, DUMMY)), eq(archiveEntries),
-                argThat(e -> !e.matches(archiveEntries)));
-        verify(softAssert).assertThat(eq(String.format(message, DOES_NOT_CONTAIN, DUMMY)), eq(archiveEntries),
-                argThat(e -> e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, MATCHES, MATHES_PATTERN)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, CONTAINS, containsPattern)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, IS_EQUAL_TO, DUMMY)),
+                eq(archiveEntries), argThat(e -> !e.matches(archiveEntries)));
+        verify(softAssert).assertThat(eq(String.format(CONTAINS_ENTRY_WITH_RULE, DOES_NOT_CONTAIN, DUMMY)),
+                eq(archiveEntries), argThat(e -> e.matches(archiveEntries)));
         verifyNoMoreInteractions(softAssert);
+        verifyPublishAttachment(archiveEntries);
+        verifyNoMoreInteractions(attachmentPublisher);
+    }
+
+    private void verifyPublishAttachment(Set<String> attachmentContent)
+    {
+        verify(attachmentPublisher).publishAttachment("archive-entries-result-table.ftl",
+                Map.of("entryNames", attachmentContent), "Archive entries");
     }
 
     private static NamedEntry createEntry(String name, StringComparisonRule rule)
@@ -144,6 +235,14 @@ class ArchiveStepsTests
     {
         byte[] data = ResourceUtils.loadResourceAsByteArray(getClass(), "/org/vividus/steps/api/archive.zip");
         return new DataWrapper(data);
+    }
+
+    private  Set<String> createArchiveEntries()
+    {
+        Set<String> archiveEntries = new LinkedHashSet<>();
+        archiveEntries.add(IMAGE_PNG);
+        archiveEntries.add(FILE_JSON);
+        return archiveEntries;
     }
 
     private static ArchiveVariable createVariable(String path, String variableName, OutputFormat outputFormat)


### PR DESCRIPTION
` @Then("$archiveData archive contains entries with names:$parameters")`
* Add attachment with archive entries in case step failure
* Add  verification for empty archive