### PR TITLE
[docs] Add example for cookies settings in Chrome

### DIFF
--- a/docs/modules/plugins/pages/plugin-web-app.adoc
+++ b/docs/modules/plugins/pages/plugin-web-app.adoc
@@ -201,6 +201,22 @@ a|The command line (CLI) arguments to use when starting browser.
 
 |===
 
+==== How to configure user preferences for Chrome browser?
+In addition to the command line arguments, user preferences (see the _Preferences_ file in Chrome's user data directory or open `chrome://prefs-internals/` link in Chrome browser for examples) can be customised.
+
+Here is an example how to configure third-party cookies behaviour.
+
+.Add the following property to allow all cookies
+[source,properties]
+----
+web.driver.CHROME.experimental-options={"prefs": {"profile": {"cookie_controls_mode": 0}}}
+----
+The allowed values for the preference from the example are:
+
+* `0` - allow all cookies;
+* `1` - block third-party cookies;
+* `2` - block third-party cookies in Incognito mode only.
+
 include::partial$proxy-meta-tags.adoc[]
 
 == xref:commons:variables.adoc[Dynamic variables]


### PR DESCRIPTION
Closes #2944

// 0 = allow third party 
// 1 = block third party
// 2 = block third party in incognito
```
Requested capabilities:
{
  "browserName" : "chrome",
  "browserVersion" : "103.0",
  "goog:chromeOptions" : {
    "args" : [ ],
    "extensions" : [ ],
    "prefs" : {
      "profile" : {
        "cookie_controls_mode" : 2
      }
    }
  },
  "platformName" : "LINUX"
}
```
