### PR TITLE
[plugin-azure-data-factory] Fix NPE introduced by changes in Azure SDK

### DIFF
--- a/vividus-plugin-azure-data-factory/src/main/java/org/vividus/azure/datafactory/steps/DataFactorySteps.java
+++ b/vividus-plugin-azure-data-factory/src/main/java/org/vividus/azure/datafactory/steps/DataFactorySteps.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.management.profile.AzureProfile;
+import com.azure.core.util.Context;
 import com.azure.resourcemanager.datafactory.DataFactoryManager;
 import com.azure.resourcemanager.datafactory.fluent.models.PipelineRunInner;
 import com.azure.resourcemanager.datafactory.models.PipelineRun;
@@ -109,7 +110,7 @@ public class DataFactorySteps
         Map<String, Object> parameters = StringUtils.isNotBlank(inputParametersJson) ? jsonUtils.toObject(
                 inputParametersJson, Map.class) : null;
         String runId = dataFactoryManager.pipelines().createRunWithResponse(resourceGroupName, factoryName,
-                pipelineName, null, null, null, null, parameters, null).getValue().runId();
+                pipelineName, null, null, null, null, parameters, Context.NONE).getValue().runId();
         LOGGER.info("The ID of the created pipeline run is {}", runId);
         PipelineRun pipelineRun = new DurationBasedWaiter(new WaitMode(waitTimeout, RETRY_TIMES)).wait(
                 () -> getPipelineRun(resourceGroupName, factoryName, runId),

--- a/vividus-plugin-azure-data-factory/src/test/java/org/vividus/azure/datafactory/steps/DataFactoryStepsTests.java
+++ b/vividus-plugin-azure-data-factory/src/test/java/org/vividus/azure/datafactory/steps/DataFactoryStepsTests.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.rest.Response;
 import com.azure.core.management.profile.AzureProfile;
+import com.azure.core.util.Context;
 import com.azure.resourcemanager.datafactory.DataFactoryManager;
 import com.azure.resourcemanager.datafactory.fluent.models.PipelineRunInner;
 import com.azure.resourcemanager.datafactory.fluent.models.PipelineRunsQueryResponseInner;
@@ -174,7 +175,7 @@ class DataFactoryStepsTests
 
             var pipelines = mock(Pipelines.class);
             when(pipelines.createRunWithResponse(RESOURCE_GROUP_NAME, FACTORY_NAME, PIPELINE_NAME, null, null, null,
-                    null, expectedParameters, null)).thenReturn(response);
+                    null, expectedParameters, Context.NONE)).thenReturn(response);
 
             when(dataFactoryManager.pipelines()).thenReturn(pipelines);
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-java/issues/30171

Exception stack-trace:
```
java.lang.NullPointerException: 'from' cannot be null.
  at java.base/java.util.Objects.requireNonNull(Objects.java:246)
  at com.azure.core.util.CoreUtils.mergeContexts(CoreUtils.java:367)
  at com.azure.resourcemanager.datafactory.implementation.DataFactoryManagementClientImpl.mergeContext(DataFactoryManagementClientImpl.java:445)
  at com.azure.resourcemanager.datafactory.implementation.PipelinesClientImpl.createRunWithResponseAsync(PipelinesClientImpl.java:1036)
  at com.azure.resourcemanager.datafactory.implementation.PipelinesClientImpl.createRunWithResponse(PipelinesClientImpl.java:1191)
  at com.azure.resourcemanager.datafactory.implementation.PipelinesImpl.createRunWithResponse(PipelinesImpl.java:100)
  at org.vividus.azure.datafactory.steps.DataFactorySteps.runPipeline(DataFactorySteps.java:111)
```