### PR TITLE
Always use JUnit BOM to manage JUnit dependencies

### DIFF
--- a/vividus-agent-reportportal/build.gradle
+++ b/vividus-agent-reportportal/build.gradle
@@ -15,7 +15,8 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'org.vividus', name: 'jbehave-core', version: versions.jbehave)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-allure-adaptor/build.gradle
+++ b/vividus-allure-adaptor/build.gradle
@@ -22,7 +22,8 @@ dependencies {
     implementation(group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0')
     implementation(group: 'com.github.valfirst', name: 'allure-notifications', version: '5e31897ab0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-analytics/build.gradle
+++ b/vividus-analytics/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'org.apache.commons', name: 'commons-collections4', version: '4.4')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
 }

--- a/vividus-engine/build.gradle
+++ b/vividus-engine/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
     runtimeOnly(group: 'org.vividus', name: 'jbehave-spring', version: versions.jbehave)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-exporter-commons/build.gradle
+++ b/vividus-exporter-commons/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation(group: 'org.springframework.boot', name: 'spring-boot-starter', version: "${springBootVersion}")
 
     testImplementation (group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "${springBootVersion}")
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
 }

--- a/vividus-exporter-commons/dependencies.gradle
+++ b/vividus-exporter-commons/dependencies.gradle
@@ -26,7 +26,8 @@ dependencies {
     implementation(group: 'org.apache.logging.log4j', name: 'log4j-slf4j18-impl')
 
     testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.4.1')
 }

--- a/vividus-extension-azure/build.gradle
+++ b/vividus-extension-azure/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation project(':vividus-engine')
     implementation project(':vividus-soft-assert')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-extension-selenium/build.gradle
+++ b/vividus-extension-selenium/build.gradle
@@ -34,7 +34,8 @@ project.description = 'Vividus extension for selenium'
 
      compileOnly(group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsVersion)
 
-     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
      testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
      testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
      testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-extension-visual-testing/build.gradle
+++ b/vividus-extension-visual-testing/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
 }

--- a/vividus-facade-jira/build.gradle
+++ b/vividus-facade-jira/build.gradle
@@ -6,7 +6,8 @@ dependencies {
 
     implementation(group: 'com.google.guava', name: 'guava', version: '31.1-jre')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-http-client/build.gradle
+++ b/vividus-http-client/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation(group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-accessibility/build.gradle
+++ b/vividus-plugin-accessibility/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-applitools/build.gradle
+++ b/vividus-plugin-applitools/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     implementation(group: 'com.applitools', name: 'eyes-images-java3', version: '3.213.0')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
 }

--- a/vividus-plugin-avro/build.gradle
+++ b/vividus-plugin-avro/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     implementation(group: 'org.apache.avro', name: 'avro', version: '1.11.1')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
 }

--- a/vividus-plugin-aws-dynamodb/build.gradle
+++ b/vividus-plugin-aws-dynamodb/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     implementation(group: 'com.amazonaws', name: 'aws-java-sdk-sts')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-aws-kinesis/build.gradle
+++ b/vividus-plugin-aws-kinesis/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation(group: 'com.amazonaws', name: 'aws-java-sdk-kinesis')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-aws-lambda/build.gradle
+++ b/vividus-plugin-aws-lambda/build.gradle
@@ -5,7 +5,8 @@ dependencies {
     implementation platform(group: 'com.amazonaws', name: 'aws-java-sdk-bom', version: '1.12.262')
     implementation(group: 'com.amazonaws', name: 'aws-java-sdk-lambda')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-aws-s3/build.gradle
+++ b/vividus-plugin-aws-s3/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-cosmos-db/build.gradle
+++ b/vividus-plugin-azure-cosmos-db/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation(group: 'com.azure', name: 'azure-cosmos')
     implementation(group: 'com.google.guava', name: 'guava', version: '31.1-jre')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-data-factory/build.gradle
+++ b/vividus-plugin-azure-data-factory/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-datafactory', version: '1.0.0-beta.16')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-event-grid/build.gradle
+++ b/vividus-plugin-azure-event-grid/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     implementation(group: 'com.azure', name: 'azure-messaging-eventgrid')
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-resources', version: '2.17.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-event-hub/build.gradle
+++ b/vividus-plugin-azure-event-hub/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-eventhubs', version: '2.17.0')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-functions/build.gradle
+++ b/vividus-plugin-azure-functions/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-appservice', version: '2.17.0')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-key-vault/build.gradle
+++ b/vividus-plugin-azure-key-vault/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation project(':vividus-soft-assert')
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-resources', version: '2.17.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-resource-manager/build.gradle
+++ b/vividus-plugin-azure-resource-manager/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation project(':vividus-soft-assert')
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-resources', version: '2.17.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-sql-db/build.gradle
+++ b/vividus-plugin-azure-sql-db/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation project(':vividus-soft-assert')
     implementation(group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-resources', version: '2.17.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-storage-account/build.gradle
+++ b/vividus-plugin-azure-storage-account/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     implementation(group: 'com.google.guava', name: 'guava', version: '31.1-jre')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-azure-storage-queue/build.gradle
+++ b/vividus-plugin-azure-storage-queue/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation(group: 'com.azure', name: 'azure-storage-queue')
     implementation(group: 'com.google.guava', name: 'guava', version: '31.1-jre')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-browserstack/build.gradle
+++ b/vividus-plugin-browserstack/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     implementation(group: 'com.browserstack', name: 'automate-client-java', version: '0.8')
     implementation(group: 'com.browserstack', name: 'browserstack-local-java', version: '1.0.6')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-crossbrowsertesting/build.gradle
+++ b/vividus-plugin-crossbrowsertesting/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     // https://github.com/valfirst/cbthelper-java
     implementation(group: 'com.github.valfirst', name: 'cbthelper-java', version: '4e195309e4')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-csv/build.gradle
+++ b/vividus-plugin-csv/build.gradle
@@ -5,7 +5,8 @@ dependencies {
     api(group: 'org.apache.commons', name: 'commons-csv', version: '1.9.0')
     implementation project(':vividus-util')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-datetime/build.gradle
+++ b/vividus-plugin-datetime/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation(group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0')
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
 }

--- a/vividus-plugin-db/build.gradle
+++ b/vividus-plugin-db/build.gradle
@@ -13,7 +13,8 @@ dependencies {
 
     testCompileOnly(group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsVersion)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
 }

--- a/vividus-plugin-electron/build.gradle
+++ b/vividus-plugin-electron/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     api project(':vividus-engine')
     implementation project(':vividus-plugin-web-app')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
 }

--- a/vividus-plugin-email/build.gradle
+++ b/vividus-plugin-email/build.gradle
@@ -19,7 +19,8 @@ dependencies {
 
     compileOnly(group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsVersion)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.icegreen', name: 'greenmail', version: '1.6.10')
     testImplementation(group: 'com.sun.mail', name: 'smtp', version: mailVersion)

--- a/vividus-plugin-excel/build.gradle
+++ b/vividus-plugin-excel/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     api(group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.2')
     implementation(group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-html/build.gradle
+++ b/vividus-plugin-html/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     implementation project(':vividus-soft-assert')
 
     testImplementation project(':vividus-util')
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-json/build.gradle
+++ b/vividus-plugin-json/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation(group: 'net.javacrumbs.json-unit', name: 'json-unit', version: '2.35.0')
     implementation(group: 'com.flipkart.zjsonpatch', name: 'zjsonpatch', version: '0.4.12')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
 }

--- a/vividus-plugin-kafka/build.gradle
+++ b/vividus-plugin-kafka/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation(group: 'org.springframework.kafka', name: 'spring-kafka', version: "${springKafkaVersion}")
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-lambdatest/build.gradle
+++ b/vividus-plugin-lambdatest/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(':vividus-engine')
     implementation project(':vividus-extension-selenium')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
 }

--- a/vividus-plugin-mobile-app/build.gradle
+++ b/vividus-plugin-mobile-app/build.gradle
@@ -10,7 +10,8 @@ project.description = 'Vividus plugin for testing mobile applications'
      implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
      implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
      testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
      testImplementation(group: 'org.mockito', name: 'mockito-inline', version: '4.6.1')
      testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')

--- a/vividus-plugin-mongodb/build.gradle
+++ b/vividus-plugin-mongodb/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation(group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.7.1')
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-parquet/build.gradle
+++ b/vividus-plugin-parquet/build.gradle
@@ -21,7 +21,8 @@ dependencies {
     implementation(group: 'org.apache.parquet', name: 'parquet-avro', version: '1.12.3')
     implementation(group: 'org.apache.hadoop', name: 'hadoop-common', version: "${hadoopVersion}")
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation(group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: "${hadoopVersion}")
 }

--- a/vividus-plugin-rest-api/build.gradle
+++ b/vividus-plugin-rest-api/build.gradle
@@ -24,7 +24,8 @@ dependencies {
     }
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-ssh/build.gradle
+++ b/vividus-plugin-ssh/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     implementation(group: 'com.jcraft', name: 'jsch.agentproxy.jsch', version: '0.0.9')
     implementation(group: 'com.jcraft', name: 'jsch.agentproxy.connector-factory', version: '0.0.9')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-visual/build.gradle
+++ b/vividus-plugin-visual/build.gradle
@@ -23,7 +23,8 @@ dependencies {
 
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-web-app-to-rest-api/build.gradle
+++ b/vividus-plugin-web-app-to-rest-api/build.gradle
@@ -15,7 +15,8 @@ dependencies {
         exclude module: 'log4j-slf4j-impl'
     }
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-web-app/build.gradle
+++ b/vividus-plugin-web-app/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'javax.inject', name: 'javax.inject', version: '1')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-websocket/build.gradle
+++ b/vividus-plugin-websocket/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation(group: 'org.springframework', name: 'spring-websocket', version: versions.spring)
     implementation(group: 'org.eclipse.jetty.websocket', name: 'websocket-client', version: '9.4.48.v20220622')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')

--- a/vividus-plugin-xml/build.gradle
+++ b/vividus-plugin-xml/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':vividus-util')
     implementation(group: 'org.xmlunit', name: 'xmlunit-core', version: '2.9.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
 }

--- a/vividus-reporter/build.gradle
+++ b/vividus-reporter/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     implementation(group: 'org.apache.commons', name: 'commons-text', version: '1.9')
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
 }

--- a/vividus-soft-assert/build.gradle
+++ b/vividus-soft-assert/build.gradle
@@ -7,7 +7,8 @@ dependencies {
     implementation(group: 'org.slf4j', name: 'slf4j-api', version: versions.slf4j)
     implementation(group: 'com.google.guava', name: 'guava', version: '31.1-jre')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.6.1')
     testImplementation(group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.10.1')

--- a/vividus-test-context/build.gradle
+++ b/vividus-test-context/build.gradle
@@ -1,6 +1,7 @@
 project.description = 'Vividus test context'
 
 dependencies {
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-core', version: '4.6.1')
 }

--- a/vividus/build.gradle
+++ b/vividus/build.gradle
@@ -68,7 +68,8 @@ dependencies {
     implementation(group: 'org.apache.commons', name: 'commons-jexl3', version: '3.2.1')
     implementation(group: 'net.datafaker', name: 'datafaker', version: '1.5.0')
 
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2')
+    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.8.2')
+    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '4.6.1')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.mockito', name: 'mockito-inline')


### PR DESCRIPTION
Dependabot can't group dependencies of the same project and creates separate PRs: #3015 and #3019. In order to unify dependencies management BOM should be used even for single dependency.