### PR TITLE
[allure-adaptor] Reduce scope of used Allure dependencies

### DIFF
--- a/vividus-allure-adaptor/build.gradle
+++ b/vividus-allure-adaptor/build.gradle
@@ -6,9 +6,6 @@ dependencies {
     implementation project(':vividus-reporter')
     implementation project(':vividus-util')
 
-    api(group: 'io.qameta.allure', name: 'allure-model', version: versions.allure)
-    api(group: 'io.qameta.allure', name: 'allure-plugin-api', version: versions.allure)
-
     implementation(group: 'io.qameta.allure', name: 'allure-java-commons', version: versions.allure)
     implementation(group: 'io.qameta.allure', name: 'allure-generator', version: versions.allure)
     implementation(group: 'io.qameta.allure', name: 'allure-plugin-api', version: versions.allure)


### PR DESCRIPTION
This PR is a cleanup of leftovers: allure dependencies of `api` scope are not needed after this refactoring: https://github.com/vividus-framework/vividus/pull/2626