### PR TITLE
[plugin-saucelabs] Rely on `SauceTunnelManager` internals managing `SauceREST` client

### DIFF
--- a/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceConnectManager.java
+++ b/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceConnectManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.saucelabs.ci.sauceconnect.SauceTunnelManager;
+import com.saucelabs.saucerest.DataCenter;
 
 import org.vividus.selenium.tunnel.TunnelManager;
 import org.vividus.testcontext.TestContext;
@@ -31,12 +32,24 @@ public class SauceConnectManager implements TunnelManager<SauceConnectOptions>
 {
     private static final Object KEY = SauceConnectDescriptor.class;
 
-    private SauceTunnelManager sauceTunnelManager;
-    private String sauceLabsUsername;
-    private String sauceLabsAccessKey;
+    private final String sauceLabsUsername;
+    private final String sauceLabsAccessKey;
+    private final DataCenter sauceLabsDataCenter;
+
+    private final SauceTunnelManager sauceTunnelManager;
+    private final TestContext testContext;
 
     private final Map<SauceConnectOptions, SauceConnectDescriptor> activeConnections = new HashMap<>();
-    private TestContext testContext;
+
+    public SauceConnectManager(String sauceLabsUsername, String sauceLabsAccessKey, DataCenter sauceLabsDataCenter,
+            SauceTunnelManager sauceTunnelManager, TestContext testContext)
+    {
+        this.sauceLabsUsername = sauceLabsUsername;
+        this.sauceLabsAccessKey = sauceLabsAccessKey;
+        this.sauceLabsDataCenter = sauceLabsDataCenter;
+        this.sauceTunnelManager = sauceTunnelManager;
+        this.testContext = testContext;
+    }
 
     @Override
     public String start(SauceConnectOptions sauceConnectOptions)
@@ -61,7 +74,7 @@ public class SauceConnectManager implements TunnelManager<SauceConnectOptions>
                 }
                 synchronized (sauceTunnelManager)
                 {
-                    sauceTunnelManager.openConnection(sauceLabsUsername, sauceLabsAccessKey,
+                    sauceTunnelManager.openConnection(sauceLabsUsername, sauceLabsAccessKey, sauceLabsDataCenter.name(),
                             sauceConnectDescriptor.getPort(), null, sauceConnectDescriptor.getOptions(), null,
                             Boolean.TRUE, null);
                 }
@@ -107,26 +120,6 @@ public class SauceConnectManager implements TunnelManager<SauceConnectOptions>
         {
             sauceTunnelManager.closeTunnelsForPlan(sauceLabsUsername, descriptor.getOptions(), null);
         }
-    }
-
-    public void setSauceTunnelManager(SauceTunnelManager sauceTunnelManager)
-    {
-        this.sauceTunnelManager = sauceTunnelManager;
-    }
-
-    public void setSauceLabsUsername(String sauceLabsUsername)
-    {
-        this.sauceLabsUsername = sauceLabsUsername;
-    }
-
-    public void setSauceLabsAccessKey(String sauceLabsAccessKey)
-    {
-        this.sauceLabsAccessKey = sauceLabsAccessKey;
-    }
-
-    public void setTestContext(TestContext testContext)
-    {
-        this.testContext = testContext;
     }
 
     public SauceConnectDescriptor getSauceConnectDescriptor()

--- a/vividus-plugin-saucelabs/src/main/resources/spring.xml
+++ b/vividus-plugin-saucelabs/src/main/resources/spring.xml
@@ -7,23 +7,16 @@
        http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd"
        profile="saucelabs" default-lazy-init="true">
 
-    <bean id="sauceRest" class="com.saucelabs.saucerest.SauceREST">
+    <bean id="sauceConnectManager" class="org.vividus.selenium.sauce.SauceConnectManager">
         <constructor-arg index="0" value="${selenium.grid.username}" />
         <constructor-arg index="1" value="${selenium.grid.password}" />
         <constructor-arg index="2" value="${saucelabs.data-center}" />
-    </bean>
-
-    <bean id="sauceConnectManager" class="org.vividus.selenium.sauce.SauceConnectManager">
-        <property name="sauceLabsUsername" value="${selenium.grid.username}"/>
-        <property name="sauceLabsAccessKey" value="${selenium.grid.password}"/>
-        <property name="testContext" ref="testContext"/>
-        <property name="sauceTunnelManager">
+        <constructor-arg>
             <bean class="com.saucelabs.ci.sauceconnect.SauceConnectFourManager">
                 <constructor-arg value="false"/>
                 <property name="useLatestSauceConnect" value="${saucelabs.sauce-connect.use-latest-version}"/>
-                <property name="sauceRest" ref="sauceRest" />
             </bean>
-        </property>
+        </constructor-arg>
     </bean>
 
     <bean id="sauceLabsLinkPublisher" class="org.vividus.saucelabs.SauceLabsTestLinkPublisher">
@@ -34,7 +27,7 @@
 
     <bean class="org.vividus.selenium.sauce.SauceLabsCapabilitiesConfigurer">
         <property name="tunnellingEnabled" value="${saucelabs.sauce-connect.enabled}"/>
-        <property name="restUrl" value="#{sauceRest.getRestApiEndpoint()}" />
+        <property name="restUrl" value="#{T(com.saucelabs.saucerest.DataCenter).fromString('${saucelabs.data-center}').server() + 'rest/v1/'}" />
         <property name="sauceConnectArguments" value="${saucelabs.sauce-connect.command-line-arguments}" />
         <property name="skipHostGlobPatterns" value="${saucelabs.sauce-connect.skip-host-glob-patterns}" />
     </bean>


### PR DESCRIPTION
This change is possible because of update in `ci-sauce:1.161`: https://github.com/saucelabs/ci-sauce/pull/128