### PR TITLE
[azure-devops-exporter] Allow to build area path from project name only

### DIFF
--- a/docs/modules/integrations/pages/azure-devops-exporter.adoc
+++ b/docs/modules/integrations/pages/azure-devops-exporter.adoc
@@ -38,10 +38,12 @@ Please make sure that the `bdd.configuration.formats` property includes JSON val
 |string
 |Project ID or project name.
 
-|`*azure-devops-exporter.area*`
+|`azure-devops-exporter.area`
 |
 |string
-|The area of the product which a test case is associated with.
+a|The area of the product which a test case is associated with.
+
+If the Area name is inherited from the Project name in AzureDevOps this property should be empty. You can check this by making a request for any https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/get-work-item?view=azure-devops-rest-7.1&tabs=HTTP[Work Item] within current Area and checking if the `System.AreaPath` contains any data besides the Project name.
 
 |`azure-devops-exporter.section-mapping.steps`
 |`AUTOMATED`

--- a/vividus-to-azure-devops-exporter/src/main/java/org/vividus/azure/devops/facade/AzureDevOpsFacade.java
+++ b/vividus-to-azure-devops-exporter/src/main/java/org/vividus/azure/devops/facade/AzureDevOpsFacade.java
@@ -281,8 +281,12 @@ public class AzureDevOpsFacade
     private List<AddOperation> createCommonOperations(String testTitle)
     {
         List<AddOperation> operations = new ArrayList<>();
-        operations.add(new AddOperation("/fields/System.AreaPath", format("%s\\%s", options.getProject(),
-                options.getArea())));
+        String areaPath = options.getProject();
+        if (options.getArea() != null)
+        {
+            areaPath += "\\" + options.getArea();
+        }
+        operations.add(new AddOperation("/fields/System.AreaPath", areaPath));
         operations.add(new AddOperation("/fields/System.Title", testTitle));
         return operations;
     }

--- a/vividus-to-azure-devops-exporter/src/test/java/org/vividus/azure/devops/facade/AzureDevOpsFacadeTests.java
+++ b/vividus-to-azure-devops-exporter/src/test/java/org/vividus/azure/devops/facade/AzureDevOpsFacadeTests.java
@@ -260,16 +260,21 @@ class AzureDevOpsFacadeTests
         verifyCreateTestCaseLog();
     }
 
-    @Test
-    void shouldUpdateTestCase() throws IOException, SyntaxException
+    @CsvSource({
+        "area, project\\area",
+        ", project"
+    })
+    @ParameterizedTest
+    void shouldUpdateTestCase(String area, String path) throws IOException, SyntaxException
     {
         SectionMapping mapping = new SectionMapping();
         mapping.setSteps(ScenarioPart.AUTOMATED);
         options.setSectionMapping(mapping);
+        options.setArea(area);
         facade.updateTestCase(TEST_CASE_ID, SUITE_TITLE, createScenario(List.of(createStep(WHEN_STEP))));
         verify(client).updateTestCase(eq(TEST_CASE_ID), operationsCaptor.capture());
         assertOperations(5, ops -> assertAll(
-            () -> assertAreaPath(ops.get(0)),
+            () -> assertAreaPath(ops.get(0), path),
             () -> assertTitle(ops.get(1)),
             () -> assertSteps(ops.get(2), STEPS),
             () -> assertAutomatedTestName(ops.get(3)),
@@ -412,7 +417,12 @@ class AzureDevOpsFacadeTests
 
     private void assertAreaPath(AddOperation operation)
     {
-        assertOperation(operation, "/fields/System.AreaPath", PROJECT + '\\' + AREA);
+        assertAreaPath(operation, PROJECT + '\\' + AREA);
+    }
+
+    private void assertAreaPath(AddOperation operation, String value)
+    {
+        assertOperation(operation, "/fields/System.AreaPath", value);
     }
 
     private void assertTitle(AddOperation operation)


### PR DESCRIPTION
Fixes #3076