### PR TITLE
[vividus] countScenarios task calculation fixing

### DIFF
--- a/vividus/src/main/java/org/vividus/runner/BddScenariosCounter.java
+++ b/vividus/src/main/java/org/vividus/runner/BddScenariosCounter.java
@@ -16,7 +16,10 @@
 
 package org.vividus.runner;
 
-import java.util.Properties;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -25,11 +28,20 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.jbehave.core.junit.JUnit4StoryRunner;
-import org.junit.runner.Description;
+import org.apache.commons.lang3.StringUtils;
+import org.jbehave.core.configuration.Configuration;
+import org.jbehave.core.configuration.Keywords;
+import org.jbehave.core.model.ExamplesTable;
+import org.jbehave.core.model.ExamplesTableFactory;
+import org.jbehave.core.model.Scenario;
+import org.jbehave.core.model.Story;
+import org.jbehave.core.parsers.RegexStoryParser;
 import org.junit.runners.model.InitializationError;
+import org.vividus.IPathFinder;
+import org.vividus.batch.BatchResourceConfiguration;
 import org.vividus.configuration.BeanFactory;
 import org.vividus.configuration.Vividus;
+import org.vividus.resource.StoryLoader;
 
 public final class BddScenariosCounter
 {
@@ -40,7 +52,14 @@ public final class BddScenariosCounter
     {
     }
 
-    public static void main(String[] args) throws ParseException, InitializationError, ReflectiveOperationException
+    public static void main(String[] args) throws ParseException, InitializationError,
+            ReflectiveOperationException, IOException
+    {
+        BddScenariosCounter bddScenariosCounter = new BddScenariosCounter();
+        bddScenariosCounter.countScenario(args);
+    }
+
+    public void countScenario(String[] args) throws ParseException, IOException
     {
         Vividus.init();
         CommandLineParser parser = new DefaultParser();
@@ -55,34 +74,64 @@ public final class BddScenariosCounter
             new HelpFormatter().printHelp("ScenariosCounter", options);
             return;
         }
-
         String storyLocation = commandLine.hasOption(directoryOption.getOpt())
                 ? commandLine.getOptionValue(directoryOption.getOpt()) : DEFAULT_STORY_LOCATION;
-        configureStoryLocation(storyLocation);
-
-        System.out.println("Story parsing may take up to 5 minutes. Please be patient.");
-        JUnit4StoryRunner runner = new JUnit4StoryRunner(StoriesRunner.class);
-
-        print(getNumberOfChildren(runner.getDescription(), Level.STORY.getLevel()), "Stories");
-        print(getNumberOfChildren(runner.getDescription(), Level.SCENARIO.getLevel()), "Scenarios");
-        print(getNumberOfChildren(runner.getDescription(), Level.EXAMPLE.getLevel()), "Scenarios with Examples");
+        StoryLoader storyLoader = BeanFactory.getBean(StoryLoader.class);
+        IPathFinder pathFinder = BeanFactory.getBean(IPathFinder.class);
+        Configuration configuration = BeanFactory.getBean(Configuration.class);
+        List<Story> stories = countStories(configuration, storyLoader, pathFinder, storyLocation);
+        int countScenarios = (int) stories.stream()
+                .flatMap(story -> story.getScenarios().stream())
+                .count();
+        int countScenariosEx = countScenariosWithExamples(stories);
+        print(stories.size(), "Stories");
+        print(countScenarios, "Scenarios");
+        print(countScenariosEx, "All executed scenarios (with Examples)");
     }
 
-    private static int getNumberOfChildren(Description description, int level)
+    private int countScenariosWithExamples(List<Story> stories)
     {
-        if (level < 1)
+        AtomicInteger countAllScenariosWithExamples = new AtomicInteger();
+        stories.forEach(story ->
         {
-            return 1;
-        }
-        int childrenNumber = 0;
-        for (Description childDescription : description.getChildren())
-        {
-            if (childDescription.getMethodName() == null)
+            int countLifecycleExamples = story.getLifecycle().getExamplesTable().getRowCount();
+            countLifecycleExamples = countLifecycleExamples > 0 ? countLifecycleExamples : 1;
+            AtomicInteger countScenariosWithExamples = new AtomicInteger();
+            List<Scenario> scenarios = story.getScenarios().stream().collect(Collectors.toList());
+            scenarios.forEach(scenario ->
             {
-                childrenNumber += getNumberOfChildren(childDescription, level - 1);
+                if (!scenario.getExamplesTable().isEmpty())
+                {
+                    countScenariosWithExamples.addAndGet(scenario.getExamplesTable().getRowCount());
+                }
+                else
+                {
+                    countScenariosWithExamples.incrementAndGet();
+                }
+            });
+            countAllScenariosWithExamples.addAndGet(countLifecycleExamples * countScenariosWithExamples.get());
+        });
+        return countAllScenariosWithExamples.get();
+    }
+
+    private List<Story> countStories(Configuration configuration, StoryLoader storyLoader, IPathFinder pathFinder,
+                                     String storyLocation) throws IOException
+    {
+        Keywords keywords = configuration.keywords();
+        RegexStoryParser storyParser = new RegexStoryParser(new ExamplesTableFactory(keywords, null, null)
+        {
+            @Override
+            public ExamplesTable createExamplesTable(String input)
+            {
+                return new ExamplesTable(input);
             }
-        }
-        return childrenNumber > 0 ? childrenNumber : 1;
+        });
+        BatchResourceConfiguration batchResourceConfiguration = createResourceBatch(storyLocation);
+        return pathFinder.findPaths(batchResourceConfiguration)
+                .stream()
+                .map(storyLoader::loadResourceAsText)
+                .map(storyParser::parseStory)
+                .collect(Collectors.toList());
     }
 
     private static void print(int number, String message)
@@ -91,28 +140,12 @@ public final class BddScenariosCounter
         System.out.println();
     }
 
-    private static void configureStoryLocation(String storyLocation)
+    private BatchResourceConfiguration createResourceBatch(String storyLocation)
     {
-        Properties properties = BeanFactory.getBean("properties", Properties.class);
-        properties.put("bdd.story-loader.batch1.resource-location", storyLocation);
-        properties.put("bdd.story-loader.batch1.resource-include-patterns", "**/*.story");
-        properties.put("bdd.story-loader.batch1.resource-exclude-patterns", "");
-    }
-
-    private enum Level
-    {
-        STORY(1), SCENARIO(2), EXAMPLE(3);
-
-        private final int level;
-
-        Level(int level)
-        {
-            this.level = level;
-        }
-
-        private int getLevel()
-        {
-            return level;
-        }
+        BatchResourceConfiguration batchResourceConfiguration = new BatchResourceConfiguration();
+        batchResourceConfiguration.setResourceLocation(storyLocation);
+        batchResourceConfiguration.setResourceIncludePatterns("**/*.story");
+        batchResourceConfiguration.setResourceExcludePatterns(StringUtils.EMPTY);
+        return batchResourceConfiguration;
     }
 }


### PR DESCRIPTION
* At the current moment 
1) `countScenarios` is using properties' files (overriding.properties) instead of argument `dir` in CMD. 
```
    private static void configureStoryLocation(String storyLocation)
    {
        Properties properties = BeanFactory.getBean("properties", Properties.class);
        properties.put("bdd.story-loader.batch-1.resource-location", storyLocation);
        properties.put("bdd.story-loader.batch-1.resource-include-patterns", "**/*.story");
        properties.put("bdd.story-loader.batch-1.resource-exclude-patterns", "");
    }
```
doesn't help.

2) It is using `JUnit4StoryRunner runner = new JUnit4StoryRunner(StoriesRunner.class);`  and `runner.getDescription()` for calculating, but there is a problem with Lifecycle Examples (`Scenarios` count more than expected, but `Scenarios with Examples` is right). For example:
```
Lifecycle:
Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/stickyHeader.html'
Examples:
|action         |firstP             |batchName           |
|COMPARE_AGAINST|By.xpath((.//p)[1])|Vividus System Tests|
|COMPARE_AGAINST|By.xpath((.//p)[2])|Vividus System Tests|
```
3) Also when we specify empty directory we want to see `0 | Stories`, but now it is `1 | Stories`.

4) For executing `./gradlew countScenarios -p vividus-tests` it is necessary to specify properties in `overriding.properties` file to avoid errors (for example, `Exception in thread "main" org.vividus.resource.ResourceLoadException: No ExamplesTable resource is found for /data/tables/system/mobile_app/locators/${target-platform}.table` ). Also there is a problem with such scenario:
```
Scenario: Should use Examples Table from temporary local file
Then `<name>` is equal to `testValue`
Examples:
file:///${examples-table-temporary-file}
```

* Proposed in PR solution doesn't work when in Lifecycle Examples contains file (doesn't calculate these scenarios). For example:
```
Lifecycle:
Examples:
/data/tables/system/mobile_app/locators/${target-platform}.table
```

After executing `./gradlew countScenarios -p vividus-tests`
![image](https://user-images.githubusercontent.com/18533593/190120349-7442954c-0cc0-4ceb-80fa-415950cd7ff5.png)
