### PR TITLE
[plugin-web-app] Remove GitHub token used to download Firefox binaries

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
@@ -20,9 +20,6 @@ environment-configurer.profile.operating-system=#{${selenium.grid.enabled} ? '${
 environment-configurer.profile.browser=${selenium.browser} ${selenium.grid.capabilities.browserVersion=}
 environment-configurer.profile.proxy=#{${proxy.enabled} ? 'ON' : 'OFF'}
 
-# Github token to download Firefox binaries via API: https://bonigarcia.dev/webdrivermanager/#known-issues
-system.wdm.gitHubToken=\u0067\u0068\u0070\u005f\u0071\u0068\u0030\u0031\u0066\u004d\u006d\u0067\u0049\u004f\u0031\u007a\u0030\u0037\u0077\u0032\u0073\u0047\u006d\u0037\u0057\u004a\u0035\u0065\u0032\u0042\u004b\u0048\u0063\u0063\u0032\u0043\u004a\u006a\u0031\u0068
-
 web-application.main-page-url=
 web-application.tablet-resolution-width-threshold=1024
 web-application.phone-resolution-width-threshold=640


### PR DESCRIPTION
https://bonigarcia.dev/webdrivermanager/#known-issues: 
As of WebDriverManager 5.3.0, this issue should not happen anymore (even without a GitHub token). To avoid the 403 error, an automated job in GitHub Actions mirrors the GitHub API responses twice a day. This mirror is used internally by WebDriverManager instead of querying the GitHub API.