### PR TITLE
[plugin-web-app] Fix retrieval of web element source code

### DIFF
--- a/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/listener/WebSourceCodePublishingOnFailureListener.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/listener/WebSourceCodePublishingOnFailureListener.java
@@ -99,7 +99,7 @@ public class WebSourceCodePublishingOnFailureListener extends AbstractSourceCode
     {
         try
         {
-            return ((WebElement) searchContext).getAttribute("innerHTML");
+            return webJavascriptActions.executeScript("return arguments[0].outerHTML;", searchContext);
         }
         catch (StaleElementReferenceException exception)
         {


### PR DESCRIPTION
1) need to use `outerHTML` instead of `innerHTML` in order to attach the full source code of the search context (including search context root element),
2) must to use Javascript to get HTML element property (neither `outerHTML` nor `innerHTML` are attributes, and not all drivers/browsers try to search for property if the requested attribute is not found).