### PR TITLE
[tests] Use new endpoint of VIVIDUS test site

### DIFF
--- a/vividus-tests/src/main/resources/properties/environment/environment.properties
+++ b/vividus-tests/src/main/resources/properties/environment/environment.properties
@@ -1,4 +1,4 @@
-bdd.variables.global.vividus-test-site-host=vividus-test-site.herokuapp.com
+bdd.variables.global.vividus-test-site-host=vividus-test-site.onrender.com
 bdd.variables.global.vividus-test-site-url=https://${bdd.variables.global.vividus-test-site-host}
 
 bdd.variables.global.screenshot-directory=${output.directory}/screenshots

--- a/vividus-tests/src/main/resources/story/integration/JSON - Wait for data in HTTP response.story
+++ b/vividus-tests/src/main/resources/story/integration/JSON - Wait for data in HTTP response.story
@@ -1,4 +1,4 @@
-Description: Integration tests for JsonResponseValidationSteps class (base website http://jsonpath.herokuapp.com/)
+Description: Integration tests for JsonResponseValidationSteps class
 
 Meta:
     @epic vividus-plugin-rest-api,vividus-plugin-json

--- a/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/ScrollStepsTests.story
@@ -2,7 +2,7 @@ Meta:
     @epic vividus-plugin-web-app
 
 Scenario: Scroll RIGHT for element Verify step: When I scroll context to $scrollDirection edge
-Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/scrollableElements.html'
+Given I am on a page with the URL '${vividus-test-site-url}/scrollableElements.html'
 When I change context to element located `By.id(scrollable)`
 When I scroll context to RIGHT edge
 When I change context to element located `By.id(current-horizontal):a`
@@ -36,7 +36,7 @@ When I change context to element located `By.id(current-vertical):a`
 Then the text matches '\d+'
 
 Scenario: Scroll BOTTOM for page Verify step: When I scroll context to $scrollDirection edge
-Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/scrollablePage.html'
+Given I am on a page with the URL '${vividus-test-site-url}/scrollablePage.html'
 When I scroll context to BOTTOM edge
 When I execute javascript `return document.documentElement.scrollTop` and save result to scenario variable `scroll`
 Then `${scroll}` is > `0`

--- a/vividus-tests/src/main/resources/story/integration/SslSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/SslSteps.story
@@ -6,4 +6,4 @@ Meta:
 Scenario: Verify step: "Then server `$hostname` supports secure protocols that $rule `$protocols`"
 Meta:
     @requirementId 681
-Then server `vividus-test-site.herokuapp.com` supports secure protocols that contain `TLSv1.3,TLSv1.2`
+Then server `${vividus-test-site-host}` supports secure protocols that contain `TLSv1.3,TLSv1.2`

--- a/vividus-tests/src/main/resources/story/system/ApplitoolsVisualStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/ApplitoolsVisualStepsTests.story
@@ -6,7 +6,7 @@ Meta:
 Lifecycle:
 Before:
 Scope: STORY
-Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/stickyHeader.html'
+Given I am on a page with the URL '${vividus-test-site-url}/stickyHeader.html'
 Examples:
 |action         |firstP             |batchName           |
 |COMPARE_AGAINST|By.xpath((.//p)[1])|Vividus System Tests|
@@ -58,7 +58,7 @@ When I run visual test with Applitools using:
 |full-page-with-scroll-element-area-cut |<batchName>|<action>|By.xpath(//p[position() mod 2 = 1 and position() > 10])|By.xpath(//p[position() mod 2 = 1 and position() < 10])|
 
 Scenario: Validation of contextual visual testing on a page with scrollable element
-Given I am on a page with the URL 'https://vividus-test-site.herokuapp.com/visualTestIntegration.html'
+Given I am on a page with the URL '${vividus-test-site-url}/visualTestIntegration.html'
 When I run visual test with Applitools using:
 |baselineName                          |batchName  |action  |
 |scrollable-element-context            |<batchName>|<action>|


### PR DESCRIPTION
https://blog.heroku.com/next-chapter:
"Starting November 28, 2022, we plan to stop offering free product plans and plan to start shutting down free dynos and data services."