### PR TITLE
[CI] Add step warming up the test website

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -73,6 +73,10 @@ jobs:
         distribution: 'temurin'
         java-version: 16
 
+    - name: Warm up VIVIDUS test site
+      if: matrix.platform == 'ubuntu-latest'
+      run: curl https://vividus-test-site.onrender.com/ &
+
     - name: Build
       env:
         MATRIX_PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
It seems https://render.com/ stops the test website after some period of inactivity. The goal of the new step is to start (warm up) the test website to use it integration tests.