### PR TITLE
[CI] Require Android 12 for Mobitru system tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -628,6 +628,7 @@ jobs:
                                                   -Pvividus.configuration.profiles=mobitru,mobile_app/android \
                                                   -Pvividus.selenium.grid.username=${MOBITRU_USER} \
                                                   -Pvividus.selenium.grid.password=${MOBITRU_KEY} \
+                                                  -Pvividus.selenium.grid.capabilities.platformVersion=12 \
                                                   -Pvividus.allure.history-directory=output/history/mt-android-system-tests \
                                                   -Pvividus.allure.report-directory=output/reports/mt-android-allure \
                                                   -Pvividus.allure.executor.name="Github Actions (Vividus)" \


### PR DESCRIPTION
Mobitru devices are not stable, application installation always fails for Redmi devices. Since Redmi devices are on Android 10 and lower, but majority of other devices use Android 12, it makes sense to limit the list of devices available for system tests in sake of stability.