### PR TITLE
[plugin-saucelabs] Use `tunnelName` instead of deprecated `tunnelIdentifier`

### DIFF
--- a/vividus-extension-selenium/src/main/java/org/vividus/selenium/tunnel/AbstractTunnellingCapabilitiesConfigurer.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/selenium/tunnel/AbstractTunnellingCapabilitiesConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public abstract class AbstractTunnellingCapabilitiesConfigurer<T extends TunnelO
         this.tunnelManager = tunnelManager;
     }
 
-    protected void configureTunnel(DesiredCapabilities desiredCapabilities, Consumer<String> tunnelIdConsumer)
+    protected void configureTunnel(DesiredCapabilities desiredCapabilities, Consumer<String> tunnelConsumer)
     {
         Proxy proxy = (Proxy) desiredCapabilities.getCapability(CapabilityType.PROXY);
         if (tunnellingEnabled || proxy != null)
@@ -53,10 +53,10 @@ public abstract class AbstractTunnellingCapabilitiesConfigurer<T extends TunnelO
 
             try
             {
-                String tunnelId = tunnelManager.start(options);
+                String tunnel = tunnelManager.start(options);
                 desiredCapabilities.setCapability(CapabilityType.PROXY, (Object) null);
 
-                tunnelIdConsumer.accept(tunnelId);
+                tunnelConsumer.accept(tunnel);
             }
             catch (TunnelException e)
             {

--- a/vividus-extension-selenium/src/test/java/org/vividus/selenium/tunnel/AbstractTunnellingCapabilitiesConfigurerTests.java
+++ b/vividus-extension-selenium/src/test/java/org/vividus/selenium/tunnel/AbstractTunnellingCapabilitiesConfigurerTests.java
@@ -45,11 +45,11 @@ import org.vividus.context.RunContext;
 @ExtendWith(MockitoExtension.class)
 class AbstractTunnellingCapabilitiesConfigurerTests
 {
-    private static final String TUNNEL_ID = "tunnel-id";
+    private static final String TUNNEL = "tunnel-id-or-tunnel-name";
 
     @Captor private ArgumentCaptor<TunnelOptions> optionsCaptor;
     @Mock private DesiredCapabilities capabilities;
-    @Mock private Consumer<String> tunnelIdConsumer;
+    @Mock private Consumer<String> tunnelConsumer;
     @Mock private RunContext runContext;
     @Mock private TunnelManager<TunnelOptions> tunnelManager;
     @InjectMocks private TestTunnellingCapabilitiesConfigurer tunnellingConfigurer;
@@ -64,12 +64,12 @@ class AbstractTunnellingCapabilitiesConfigurerTests
 
         when(proxy.getHttpProxy()).thenReturn(httpProxy);
         when(capabilities.getCapability(CapabilityType.PROXY)).thenReturn(proxy);
-        when(tunnelManager.start(optionsCaptor.capture())).thenReturn(TUNNEL_ID);
+        when(tunnelManager.start(optionsCaptor.capture())).thenReturn(TUNNEL);
 
-        tunnellingConfigurer.configureTunnel(capabilities, tunnelIdConsumer);
+        tunnellingConfigurer.configureTunnel(capabilities, tunnelConsumer);
 
         verify(capabilities).setCapability(CapabilityType.PROXY, (Object) null);
-        verify(tunnelIdConsumer).accept(TUNNEL_ID);
+        verify(tunnelConsumer).accept(TUNNEL);
         assertEquals(httpProxy, optionsCaptor.getValue().getProxy());
     }
 
@@ -79,12 +79,12 @@ class AbstractTunnellingCapabilitiesConfigurerTests
         tunnellingConfigurer.setTunnellingEnabled(true);
 
         when(capabilities.getCapability(CapabilityType.PROXY)).thenReturn(null);
-        when(tunnelManager.start(optionsCaptor.capture())).thenReturn(TUNNEL_ID);
+        when(tunnelManager.start(optionsCaptor.capture())).thenReturn(TUNNEL);
 
-        tunnellingConfigurer.configureTunnel(capabilities, tunnelIdConsumer);
+        tunnellingConfigurer.configureTunnel(capabilities, tunnelConsumer);
 
         verify(capabilities).setCapability(CapabilityType.PROXY, (Object) null);
-        verify(tunnelIdConsumer).accept(TUNNEL_ID);
+        verify(tunnelConsumer).accept(TUNNEL);
         assertNull(optionsCaptor.getValue().getProxy());
     }
 
@@ -95,10 +95,10 @@ class AbstractTunnellingCapabilitiesConfigurerTests
 
         when(capabilities.getCapability(CapabilityType.PROXY)).thenReturn(null);
 
-        tunnellingConfigurer.configureTunnel(capabilities, tunnelIdConsumer);
+        tunnellingConfigurer.configureTunnel(capabilities, tunnelConsumer);
 
         verifyNoMoreInteractions(capabilities);
-        verifyNoInteractions(tunnelIdConsumer);
+        verifyNoInteractions(tunnelConsumer);
     }
 
     @Test
@@ -111,11 +111,11 @@ class AbstractTunnellingCapabilitiesConfigurerTests
         doThrow(thrown).when(tunnelManager).start(optionsCaptor.capture());
 
         IllegalStateException exception = assertThrows(IllegalStateException.class,
-            () -> tunnellingConfigurer.configureTunnel(capabilities, tunnelIdConsumer));
+            () -> tunnellingConfigurer.configureTunnel(capabilities, tunnelConsumer));
 
         assertEquals(thrown, exception.getCause());
         verifyNoMoreInteractions(capabilities);
-        verifyNoInteractions(tunnelIdConsumer);
+        verifyNoInteractions(tunnelConsumer);
         assertNull(optionsCaptor.getValue().getProxy());
     }
 

--- a/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceConnectManager.java
+++ b/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceConnectManager.java
@@ -89,7 +89,7 @@ public class SauceConnectManager implements TunnelManager<SauceConnectOptions>
         {
             throw new IllegalArgumentException("Only one SauceConnect tunnel is allowed within one thread");
         }
-        return sauceConnectDescriptor.getTunnelId();
+        return sauceConnectDescriptor.getTunnelName();
     }
 
     @Override
@@ -134,20 +134,20 @@ public class SauceConnectManager implements TunnelManager<SauceConnectOptions>
 
     class SauceConnectDescriptor
     {
-        private final String tunnelId;
+        private final String tunnelName;
         private final int port;
         private final String options;
 
         SauceConnectDescriptor(SauceConnectOptions sauceConnectOptions) throws IOException
         {
-            tunnelId = UUID.randomUUID().toString();
-            options = sauceConnectOptions.build(tunnelId);
+            tunnelName = UUID.randomUUID().toString();
+            options = sauceConnectOptions.build(tunnelName);
             port = getFreePort();
         }
 
-        String getTunnelId()
+        String getTunnelName()
         {
-            return tunnelId;
+            return tunnelName;
         }
 
         int getPort()

--- a/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceConnectOptions.java
+++ b/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceConnectOptions.java
@@ -60,14 +60,14 @@ public class SauceConnectOptions extends TunnelOptions
         ));
     }
 
-    public String build(String tunnelIdentifier) throws IOException
+    public String build(String tunnelName) throws IOException
     {
         StringBuilder options = Optional.ofNullable(customArguments).map(args -> new StringBuilder(args).append(' '))
                 .orElseGet(StringBuilder::new);
-        if (tunnelIdentifier != null)
+        if (tunnelName != null)
         {
-            appendOption(options, "tunnel-identifier", tunnelIdentifier);
-            appendOption(options, "pidfile", createPidFile(tunnelIdentifier).toString());
+            appendOption(options, "tunnel-name", tunnelName);
+            appendOption(options, "pidfile", createPidFile(tunnelName).toString());
         }
 
         if (getProxy() != null)
@@ -78,7 +78,7 @@ public class SauceConnectOptions extends TunnelOptions
              * Affected SauceConnect version: 4.4.4 and above.
              * */
             appendOption(options, "pac",
-                    "file://" + FilenameUtils.separatorsToUnix(createPacFile(tunnelIdentifier).toString()));
+                    "file://" + FilenameUtils.separatorsToUnix(createPacFile(tunnelName).toString()));
         }
         if (restUrl != null)
         {
@@ -89,9 +89,9 @@ public class SauceConnectOptions extends TunnelOptions
         return options.substring(0, options.length() - 1);
     }
 
-    private Path createPacFile(String tunnelIdentifier) throws IOException
+    private Path createPacFile(String tunnelName) throws IOException
     {
-        return createTempFile("pac-saucelabs-" + tunnelIdentifier, ".js",
+        return createTempFile("pac-saucelabs-" + tunnelName, ".js",
                 String.format(PAC_FILE_CONTENT_FORMAT, getSkipShExpMatcher(), getProxy()));
     }
 
@@ -102,9 +102,9 @@ public class SauceConnectOptions extends TunnelOptions
                                    .collect(Collectors.joining(" || "));
     }
 
-    private Path createPidFile(String tunnelIdentifier) throws IOException
+    private Path createPidFile(String tunnelName) throws IOException
     {
-        return createTempFile("sc_client-" + tunnelIdentifier + "-", ".pid", null);
+        return createTempFile("sc_client-" + tunnelName + "-", ".pid", null);
     }
 
     private static void appendOption(StringBuilder stringBuilder, String name, String... values)

--- a/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurer.java
+++ b/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurer.java
@@ -39,7 +39,7 @@ public class SauceLabsCapabilitiesConfigurer extends AbstractTunnellingCapabilit
     public void configure(DesiredCapabilities desiredCapabilities)
     {
         configureTunnel(desiredCapabilities,
-                tunnelId -> putNestedCapability(desiredCapabilities, SAUCE_OPTIONS, "tunnelIdentifier", tunnelId));
+                tunnelName -> putNestedCapability(desiredCapabilities, SAUCE_OPTIONS, "tunnelName", tunnelName));
 
         configureTestName(desiredCapabilities, SAUCE_OPTIONS, "name");
     }

--- a/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceConnectManagerTests.java
+++ b/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceConnectManagerTests.java
@@ -90,10 +90,10 @@ public class SauceConnectManagerTests
     {
         mockSocket();
         var options = startConnection();
-        var tunnelId = sauceConnectManager.start(options);
+        var tunnelName = sauceConnectManager.start(options);
         verify(sauceTunnelManager, times(1)).openConnection(USERNAME, USERKEY, DATA_CENTER, 1, null, OPTIONS, null,
                 Boolean.TRUE, null);
-        assertEquals(tunnelId, sauceConnectManager.start(options));
+        assertEquals(tunnelName, sauceConnectManager.start(options));
     }
 
     @Test

--- a/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceConnectOptionsTests.java
+++ b/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceConnectOptionsTests.java
@@ -38,9 +38,9 @@ class SauceConnectOptionsTests
     private static final String DOT_JS = ".js";
     private static final String PAC_TEST_TUNNEL = "pac-saucelabs-test-tunnel";
     private static final String PROXY = "test";
-    private static final String TUNNEL_IDENTIFIER = "test-tunnel";
-    private static final String PID_FILE_NAME = "sc_client-" + TUNNEL_IDENTIFIER + "-";
-    private static final String TUNNEL_IDENTIFIER_OPTION = "--tunnel-identifier" + SPACE + TUNNEL_IDENTIFIER;
+    private static final String TUNNEL_NAME = "test-tunnel";
+    private static final String PID_FILE_NAME = "sc_client-" + TUNNEL_NAME + "-";
+    private static final String TUNNEL_NAME_OPTION = "--tunnel-name" + SPACE + TUNNEL_NAME;
     private static final String PID_EXTENSION = ".pid";
     private static final String NO_REMOVE_COLLIDING_TUNNELS = "--no-remove-colliding-tunnels";
     private static final String NO_PROXY_CACHING = "--no-proxy-caching";
@@ -73,9 +73,9 @@ class SauceConnectOptionsTests
             Path pidPath = mockPid(resources);
 
             assertEquals(
-                    TUNNEL_IDENTIFIER_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + pacPath + SPACE
+                    TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + pacPath + SPACE
                             + NO_REMOVE_COLLIDING_TUNNELS + SPACE + NO_PROXY_CACHING,
-                    sauceConnectOptions.build(TUNNEL_IDENTIFIER));
+                    sauceConnectOptions.build(TUNNEL_NAME));
         }
     }
 
@@ -91,9 +91,9 @@ class SauceConnectOptionsTests
             Path pidPath = mockPid(resources);
 
             assertEquals(
-                    TUNNEL_IDENTIFIER_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + "c:/user/temp.js"
+                    TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + "c:/user/temp.js"
                             + SPACE + NO_REMOVE_COLLIDING_TUNNELS + SPACE + NO_PROXY_CACHING,
-                    sauceConnectOptions.build(TUNNEL_IDENTIFIER));
+                    sauceConnectOptions.build(TUNNEL_NAME));
         }
     }
 
@@ -107,9 +107,9 @@ class SauceConnectOptionsTests
             Path pacPath = mockPac(resources, DEFAULT_MATCH_CHAIN);
             Path pidPath = mockPid(resources);
 
-            assertEquals(customFlags + SPACE + TUNNEL_IDENTIFIER_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE
+            assertEquals(customFlags + SPACE + TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE
                             + PAC_FILE + pacPath + SPACE + NO_REMOVE_COLLIDING_TUNNELS + SPACE + NO_PROXY_CACHING,
-                    sauceConnectOptions.build(TUNNEL_IDENTIFIER));
+                    sauceConnectOptions.build(TUNNEL_NAME));
         }
     }
 
@@ -127,9 +127,9 @@ class SauceConnectOptionsTests
             Path pidPath = mockPid(resources);
 
             assertEquals(
-                    TUNNEL_IDENTIFIER_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + pacPath + SPACE
+                    TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + pacPath + SPACE
                             + NO_REMOVE_COLLIDING_TUNNELS + SPACE + NO_PROXY_CACHING,
-                    sauceConnectOptions.build(TUNNEL_IDENTIFIER));
+                    sauceConnectOptions.build(TUNNEL_NAME));
         }
     }
 
@@ -142,9 +142,9 @@ class SauceConnectOptionsTests
 
             SauceConnectOptions sauceConnectOptions = createEmptyOptions();
             assertEquals(
-                    TUNNEL_IDENTIFIER_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + NO_REMOVE_COLLIDING_TUNNELS
+                    TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + NO_REMOVE_COLLIDING_TUNNELS
                             + SPACE + NO_PROXY_CACHING,
-                    sauceConnectOptions.build(TUNNEL_IDENTIFIER));
+                    sauceConnectOptions.build(TUNNEL_NAME));
         }
     }
 

--- a/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurerTests.java
+++ b/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurerTests.java
@@ -53,8 +53,8 @@ class SauceLabsCapabilitiesConfigurerTests
     private static final String NAME_CAPABILITY = "name";
     private static final String STORY_NAME = "my";
 
-    private static final String TUNNEL_IDENTIFIER_CAPABILITY = "tunnelIdentifier";
-    private static final String TUNNEL_ID = "tunnelId";
+    private static final String TUNNEL_NAME_CAPABILITY = "tunnelName";
+    private static final String TUNNEL_NAME = "my-tunnel-name";
 
     private static final String STORY_PATH = STORY_NAME + ".story";
 
@@ -92,11 +92,11 @@ class SauceLabsCapabilitiesConfigurerTests
         Map<String, Object> sauceOptions = new HashMap<>();
         DesiredCapabilities desiredCapabilities = mockDesiredCapabilities(null, sauceOptions);
         SauceConnectOptions sauceConnectOptions = new SauceConnectOptions(null, null, Set.of());
-        when(sauceConnectManager.start(sauceConnectOptions)).thenReturn(TUNNEL_ID);
+        when(sauceConnectManager.start(sauceConnectOptions)).thenReturn(TUNNEL_NAME);
 
         configurer.configure(desiredCapabilities);
 
-        assertEquals(Map.of(NAME_CAPABILITY, STORY_NAME, TUNNEL_IDENTIFIER_CAPABILITY, TUNNEL_ID), sauceOptions);
+        assertEquals(Map.of(NAME_CAPABILITY, STORY_NAME, TUNNEL_NAME_CAPABILITY, TUNNEL_NAME), sauceOptions);
         verifyNoMoreInteractions(sauceConnectManager);
     }
 
@@ -118,11 +118,11 @@ class SauceLabsCapabilitiesConfigurerTests
         Map<String, Object> sauceOptions = new HashMap<>();
         DesiredCapabilities desiredCapabilities = mockDesiredCapabilities(proxy, sauceOptions);
 
-        when(sauceConnectManager.start(sauceConnectOptions)).thenReturn(TUNNEL_ID);
+        when(sauceConnectManager.start(sauceConnectOptions)).thenReturn(TUNNEL_NAME);
 
         configurer.configure(desiredCapabilities);
 
-        assertEquals(Map.of(TUNNEL_IDENTIFIER_CAPABILITY, TUNNEL_ID), sauceOptions);
+        assertEquals(Map.of(TUNNEL_NAME_CAPABILITY, TUNNEL_NAME), sauceOptions);
         verifyNoMoreInteractions(sauceConnectManager);
     }
 


### PR DESCRIPTION
https://docs.saucelabs.com/dev/test-configuration-options/#tunnelidentifier: `tunnelIdentifier` is being deprecated in favor of `tunnelName`.