### PR TITLE
[plugin-json] Fix broken JSON assert with `IGNORING_EXTRA_ARRAY_ITEMS` option

### DIFF
--- a/vividus-plugin-json/src/main/java/org/vividus/json/steps/JsonSteps.java
+++ b/vividus-plugin-json/src/main/java/org/vividus/json/steps/JsonSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class JsonSteps
 {
     private static final String ASSERTION_BOUNDS = String.join("|", Set.of(
             "Different (?:value|keys) found",
-            "Array \"[^\"]*\" has different"
+            "Array \"[^\"]*\" has (different|invalid)"
     ));
     private static final char LF = '\n';
     private static final Pattern DIFFERENCES_PATTERN = Pattern.compile(

--- a/vividus-plugin-json/src/test/java/org/vividus/json/steps/JsonStepsTests.java
+++ b/vividus-plugin-json/src/test/java/org/vividus/json/steps/JsonStepsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.vividus.variable.VariableScope;
 import net.javacrumbs.jsonunit.core.Option;
 import net.javacrumbs.jsonunit.core.internal.Options;
 
+@SuppressWarnings("MethodCount")
 @ExtendWith(MockitoExtension.class)
 class JsonStepsTests
 {
@@ -429,6 +430,19 @@ class JsonStepsTests
         steps.assertElementByJsonPath(JSON, ARRAY_PATH, expectedJson,
                 new Options(Option.IGNORING_ARRAY_ORDER, Option.IGNORING_EXTRA_ARRAY_ITEMS));
         verifyJsonEqualityAssertion(ARRAY_PATH, expectedJson, ARRAY_PATH_RESULT);
+    }
+
+    @Test
+    void shouldAssertArrayByJsonPathWithDifferentArrayLengthAndIgnoringExtraArrayItemsOption()
+    {
+        var expectedJson = "[1,2,3]";
+
+        steps.assertElementByJsonPath(JSON, ARRAY_PATH, expectedJson, new Options(Option.IGNORING_EXTRA_ARRAY_ITEMS));
+
+        verify(softAssert).recordFailedAssertion("Array \"\" has invalid length, expected: <at least 3> but was: <2>.");
+        verify(softAssert).recordFailedAssertion(
+                "Array \"\" has different content. Missing values: [3], expected: <[1,2,3]> but was: <[1,2]>");
+        verifyNoMoreInteractions(softAssert);
     }
 
     @Test


### PR DESCRIPTION
Fix broken JSON comparison step with extra elements in expected JSON and using `IGNORING_EXTRA_ARRAY_ITEMS` option