### PR TITLE
[plugin-web-app] Fix execution of desktop web tests on SauceLabs

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/edge/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/edge/profile.properties
@@ -1,6 +1,8 @@
 selenium.browser=edge
 
 selenium.grid.capabilities.browserName=MicrosoftEdge
+selenium.grid.platform-name=Windows
+selenium.grid.platform-version=10
 
 selenium.screenshot.strategy=VIEWPORT_PASTING
 

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/desktop/profile.properties
@@ -3,7 +3,7 @@ bdd.all-meta-filters=groovy: (!layout || layout.contains('desktop')) && !skip &&
 selenium.grid.platform-name=
 selenium.grid.platform-version=
 
-selenium.grid.capabilities.platformName=${selenium.grid.platform-name} ${selenium.grid.platform-version}
+selenium.grid.capabilities.platformName=${selenium.grid.platform-name}#{"${selenium.grid.platform-version}".isBlank() ? "" : " ${selenium.grid.platform-version}"}
 selenium.grid.capabilities.browserName=${selenium.browser}
 
 selenium.screenshot.full-page=false


### PR DESCRIPTION
SauceLabs has started using MacOS as a default platform when `platformName` capability is equal to single whitespace, while empty `platformName` capability defaults to Windows by Selenium client.