### PR TITLE
[engine] Fix Jackson reflection issue

### DIFF
--- a/vividus-engine/src/main/java/org/vividus/batch/BatchConfiguration.java
+++ b/vividus-engine/src/main/java/org/vividus/batch/BatchConfiguration.java
@@ -164,27 +164,27 @@ public class BatchConfiguration
                      .collect(Collectors.toList());
     }
 
-    private static final class StoryExecutionConfiguration
+    public static final class StoryExecutionConfiguration
     {
         private Boolean failFast;
         private Duration executionTimeout;
 
-        private void setFailFast(Boolean failFast)
+        public void setFailFast(Boolean failFast)
         {
             this.failFast = failFast;
         }
 
-        private void setExecutionTimeout(Duration executionTimeout)
+        public void setExecutionTimeout(Duration executionTimeout)
         {
             this.executionTimeout = executionTimeout;
         }
     }
 
-    private static final class ScenarioExecutionConfiguration
+    public static final class ScenarioExecutionConfiguration
     {
         private Boolean failFast;
 
-        private void setFailFast(Boolean failFast)
+        public void setFailFast(Boolean failFast)
         {
             this.failFast = failFast;
         }


### PR DESCRIPTION
Error:
```
2023-01-18 16:23:11,653 [main] WARN  com.fasterxml.jackson.module.afterburner.deser.BeanPropertyMutator - Disabling Afterburner deserialization for class org.vividus.batch.BatchConfiguration (field #3; mutator com.fasterxml.jackson.module.afterburner.deser.SettableObjectMethodProperty), due to access error (type java.lang.IllegalAccessError, message=failed to access class org.vividus.batch.BatchConfiguration$StoryExecutionConfiguration from class org.vividus.batch.BatchConfiguration$Access4JacksonDeserializer01e8db89 (org.vividus.batch.BatchConfiguration$StoryExecutionConfiguration is in unnamed module of loader 'app'; org.vividus.batch.BatchConfiguration$Access4JacksonDeserializer01e8db89 is in unnamed module of loader com.fasterxml.jackson.module.afterburner.util.MyClassLoader @71789580))

 java.lang.IllegalAccessError: failed to access class org.vividus.batch.BatchConfiguration$StoryExecutionConfiguration from class org.vividus.batch.BatchConfiguration$Access4JacksonDeserializer01e8db89 (org.vividus.batch.BatchConfiguration$StoryExecutionConfiguration is in unnamed module of loader 'app'; org.vividus.batch.BatchConfiguration$Access4JacksonDeserializer01e8db89 is in unnamed module of loader com.fasterxml.jackson.module.afterburner.util.MyClassLoader @71789580)
        at org.vividus.batch.BatchConfiguration$Access4JacksonDeserializer01e8db89.objectSetter(org/vividus/batch/BatchConfiguration$Access4JacksonDeserializer.java) ~[?:?]
        at com.fasterxml.jackson.module.afterburner.deser.SettableObjectMethodProperty.deserializeAndSet(SettableObjectMethodProperty.java:59) ~[jackson-module-afterburner-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:278) ~[jackson-databind-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:155) ~[jackson-module-afterburner-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323) ~[jackson-databind-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4706) ~[jackson-databind-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2879) ~[jackson-databind-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper.readMapAs(JavaPropsMapper.java:179) ~[jackson-dataformat-properties-2.14.1.jar:2.14.1]
        at com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper.readMapAs(JavaPropsMapper.java:211) ~[jackson-dataformat-properties-2.14.1.jar:2.14.1]
        at org.vividus.util.property.PropertyMapper.readValues(PropertyMapper.java:134) ~[vividus-util-0.5.4-SNAPSHOT.jar:0.5.4-SNAPSHOT]
        at org.vividus.util.property.PropertyMapper.readValues(PropertyMapper.java:115) ~[vividus-util-0.5.4-SNAPSHOT.jar:0.5.4-SNAPSHOT]
        at org.vividus.batch.BatchStorage.readFromProperties(BatchStorage.java:95) ~[vividus-engine-0.5.4-SNAPSHOT.jar:0.5.4-SNAPSHOT]
        at org.vividus.batch.BatchStorage.<init>(BatchStorage.java:68) ~[vividus-engine-0.5.4-SNAPSHOT.jar:0.5.4-SNAPSHOT]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:211) ~[spring-beans-5.3.25.jar:5.3.25]
...
```

Relates to https://github.com/FasterXML/jackson-modules-base/issues/186