### PR TITLE
Remove usages of `mockito-inline` dependency

### DIFF
--- a/vividus-agent-reportportal/build.gradle
+++ b/vividus-agent-reportportal/build.gradle
@@ -22,6 +22,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-allure-adaptor/build.gradle
+++ b/vividus-allure-adaptor/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-engine/build.gradle
+++ b/vividus-engine/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
     testImplementation(group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.12.3')
 }

--- a/vividus-extension-azure/build.gradle
+++ b/vividus-extension-azure/build.gradle
@@ -9,5 +9,4 @@ dependencies {
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-extension-selenium/build.gradle
+++ b/vividus-extension-selenium/build.gradle
@@ -40,6 +40,5 @@ project.description = 'VIVIDUS extension for Selenium'
      testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
      testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
      testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-     testImplementation(group: 'org.mockito', name: 'mockito-inline')
      testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
  }

--- a/vividus-facade-jira/build.gradle
+++ b/vividus-facade-jira/build.gradle
@@ -11,5 +11,4 @@ dependencies {
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-http-client/build.gradle
+++ b/vividus-http-client/build.gradle
@@ -11,6 +11,5 @@ dependencies {
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-accessibility/build.gradle
+++ b/vividus-plugin-accessibility/build.gradle
@@ -14,6 +14,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-aws-dynamodb/build.gradle
+++ b/vividus-plugin-aws-dynamodb/build.gradle
@@ -11,6 +11,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-aws-kinesis/build.gradle
+++ b/vividus-plugin-aws-kinesis/build.gradle
@@ -10,6 +10,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-aws-lambda/build.gradle
+++ b/vividus-plugin-aws-lambda/build.gradle
@@ -9,5 +9,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-aws-s3/build.gradle
+++ b/vividus-plugin-aws-s3/build.gradle
@@ -14,6 +14,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-azure-cosmos-db/build.gradle
+++ b/vividus-plugin-azure-cosmos-db/build.gradle
@@ -12,6 +12,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.12.3')
 }

--- a/vividus-plugin-azure-data-factory/build.gradle
+++ b/vividus-plugin-azure-data-factory/build.gradle
@@ -12,6 +12,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-azure-event-grid/build.gradle
+++ b/vividus-plugin-azure-event-grid/build.gradle
@@ -13,5 +13,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-azure-event-hub/build.gradle
+++ b/vividus-plugin-azure-event-hub/build.gradle
@@ -10,6 +10,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-azure-functions/build.gradle
+++ b/vividus-plugin-azure-functions/build.gradle
@@ -12,6 +12,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-azure-resource-manager/build.gradle
+++ b/vividus-plugin-azure-resource-manager/build.gradle
@@ -10,6 +10,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '1.9.1')
 }

--- a/vividus-plugin-azure-storage-account/build.gradle
+++ b/vividus-plugin-azure-storage-account/build.gradle
@@ -16,6 +16,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-azure-storage-queue/build.gradle
+++ b/vividus-plugin-azure-storage-queue/build.gradle
@@ -12,5 +12,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-browserstack/build.gradle
+++ b/vividus-plugin-browserstack/build.gradle
@@ -17,6 +17,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-crossbrowsertesting/build.gradle
+++ b/vividus-plugin-crossbrowsertesting/build.gradle
@@ -11,6 +11,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-csv/build.gradle
+++ b/vividus-plugin-csv/build.gradle
@@ -10,5 +10,4 @@ dependencies {
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-excel/build.gradle
+++ b/vividus-plugin-excel/build.gradle
@@ -13,5 +13,4 @@ dependencies {
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-html/build.gradle
+++ b/vividus-plugin-html/build.gradle
@@ -11,5 +11,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-kafka/build.gradle
+++ b/vividus-plugin-kafka/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'org.springframework.kafka', name: 'spring-kafka-test', version: "${springKafkaVersion}")
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-mobile-app/build.gradle
+++ b/vividus-plugin-mobile-app/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 
     testCompileOnly(group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: spotbugsVersion)

--- a/vividus-plugin-mobitru/build.gradle
+++ b/vividus-plugin-mobitru/build.gradle
@@ -13,6 +13,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-mongodb/build.gradle
+++ b/vividus-plugin-mongodb/build.gradle
@@ -10,5 +10,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-rest-api/build.gradle
+++ b/vividus-plugin-rest-api/build.gradle
@@ -25,6 +25,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-shell/build.gradle
+++ b/vividus-plugin-shell/build.gradle
@@ -12,7 +12,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
-    testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '1.9.1')
 }

--- a/vividus-plugin-ssh/build.gradle
+++ b/vividus-plugin-ssh/build.gradle
@@ -14,6 +14,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-visual/build.gradle
+++ b/vividus-plugin-visual/build.gradle
@@ -27,6 +27,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-web-app-to-rest-api/build.gradle
+++ b/vividus-plugin-web-app-to-rest-api/build.gradle
@@ -20,6 +20,5 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }

--- a/vividus-plugin-web-app/build.gradle
+++ b/vividus-plugin-web-app/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '2.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
     testImplementation(group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.12.3')
 }

--- a/vividus-plugin-websocket/build.gradle
+++ b/vividus-plugin-websocket/build.gradle
@@ -13,5 +13,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-plugin-winrm/build.gradle
+++ b/vividus-plugin-winrm/build.gradle
@@ -30,5 +30,4 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
 }

--- a/vividus-to-xray-exporter/build.gradle
+++ b/vividus-to-xray-exporter/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
 }
 

--- a/vividus/build.gradle
+++ b/vividus/build.gradle
@@ -74,7 +74,6 @@ dependencies {
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.0.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '1.9.1')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.8.1')
     testImplementation(group: 'org.springframework', name: 'spring-test')


### PR DESCRIPTION
As of Mockito 5.0.0 the default mockmaker was switched to `mockito-inline`: https://github.com/mockito/mockito/releases/tag/v5.0.0