### PR TITLE
[engine] Fix parsing of nested expressions without parameters

### DIFF
--- a/vividus-engine/src/main/java/org/vividus/steps/ExpressionAdaptor.java
+++ b/vividus-engine/src/main/java/org/vividus/steps/ExpressionAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class ExpressionAdaptor implements DryRunAwareExecutor
     private static final Pattern GREEDY_EXPRESSION_PATTERN = Pattern.compile("#\\{((?:(?!#\\{|\\$\\{).)*)}",
             Pattern.DOTALL);
     private static final Pattern RELUCTANT_EXPRESSION_PATTERN = Pattern.compile(
-            "#\\{((?:(?![#{])[^)][^(][^)])*?|(?:(?!#\\{|\\$\\{).)*?\\)|(?:(?!#\\{|\\$\\{).)*?)}",
+            "#\\{((?:(?![#{])[^)](?![()]))*?|(?:(?!#\\{|\\$\\{).)*?\\)|(?:(?!#\\{|\\$\\{).)*?)}",
             Pattern.DOTALL);
 
     private static final String REPLACEMENT_PATTERN = "\\#\\{%s\\}";

--- a/vividus-engine/src/test/java/org/vividus/steps/ExpressionAdapterTests.java
+++ b/vividus-engine/src/test/java/org/vividus/steps/ExpressionAdapterTests.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -116,14 +117,15 @@ class ExpressionAdapterTests
     }
 
     @SuppressWarnings("unchecked")
-    @Test
-    void testNestedExpressionWithoutParams()
+    @ParameterizedTest
+    @ValueSource(strings = { EXPRESSION_KEYWORD, "targets" })
+    void testNestedExpressionWithoutParams(String nestedExpression)
     {
-        var input = "#{capitalize(#{trim(#{target})})}";
+        var input = String.format("#{capitalize(#{trim(#{%s})})}", nestedExpression);
         var output = "Quetzalcoatlus";
 
         var mockedExpressionProcessor = (SingleArgExpressionProcessor<String>) mock(SingleArgExpressionProcessor.class);
-        when(mockedExpressionProcessor.execute(EXPRESSION_KEYWORD)).thenReturn(Optional.of(" quetzalcoatlus "));
+        when(mockedExpressionProcessor.execute(nestedExpression)).thenReturn(Optional.of(" quetzalcoatlus "));
         IExpressionProcessor<?> processor = new DelegatingExpressionProcessor(List.of(
                 new SingleArgExpressionProcessor<>(EXPRESSION_TRIM,        StringUtils::trim),
                 new SingleArgExpressionProcessor<>(EXPRESSION_CAPITALIZE,  StringUtils::capitalize),


### PR DESCRIPTION
The previous RELUCTANT_EXPRESSION_PATTERN didn't correctly process expressions the number of characters in which was not a multiple of 3