### PR TITLE
[tests] Relax timeouts for wait-tests interacting with httpbin.org

### DIFF
--- a/vividus-tests/src/main/resources/story/integration/HttpResponseValidationStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/HttpResponseValidationStepsTests.story
@@ -45,7 +45,7 @@ Then the response time should be less than '5000' milliseconds
 
 Scenario: Verify step: "When I wait for response code `$responseCode` for `$duration` duration retrying $retryTimes times$stepsToExecute"
 Given I initialize scenario variable `relativeURL` with value `get-wrong-wrong-wrong`
-When I wait for response code `200` for `PT10S` duration retrying 3 times
+When I wait for response code `200` for `PT2M` duration retrying 3 times
 |step                                                                                                                      |
 |Given I initialize scenario variable `relativeURL` with value `#{eval(stringUtils:substringBeforeLast(relativeURL, '-'))}`|
 |When I execute HTTP GET request for resource with relative URL `${relativeURL}`                                           |

--- a/vividus-tests/src/main/resources/story/integration/JSON - Wait for data in HTTP response.story
+++ b/vividus-tests/src/main/resources/story/integration/JSON - Wait for data in HTTP response.story
@@ -27,7 +27,7 @@ When I find greater than `1` JSON elements by `$.store.book` and for each elemen
 |Then number of JSON elements by JSON path `$.author` is = 1|
 
 Scenario: Verify step "When I wait for presence of element by `$jsonPath` for `$duration` duration retrying $retryTimes times$stepsToExecute"
-When I wait for presence of element by `$.json.iteration3` for `PT15S` duration retrying 3 times
+When I wait for presence of element by `$.json.iteration3` for `PT2M` duration retrying 3 times
 |step                                                                                     |
 |Given I initialize scenario variable `iteration` with value `#{eval(${iteration:0} + 1)}`|
 |When I set request headers:                                                              |


### PR DESCRIPTION
Some requests to httpbin.org may be up to 30 seconds.