### PR TITLE
[vividus] Load Allure Log4J2 plugin from plugin listing file on classpath

### DIFF
--- a/vividus/build.gradle
+++ b/vividus/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation(group: 'org.apache.logging.log4j', name: 'log4j-api')
     implementation(group: 'org.apache.logging.log4j', name: 'log4j-core')
     implementation(group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl')
+    annotationProcessor platform(group: 'org.apache.logging.log4j', name: 'log4j-bom', version: '2.20.0')
+    annotationProcessor(group: 'org.apache.logging.log4j', name: 'log4j-core')
     implementation(group: 'de.vandermeer', name: 'asciitable', version: '0.3.2')
     // Replace commons-logging with slf4j
     implementation(group: 'org.slf4j', name: 'jcl-over-slf4j', version: versions.slf4j)

--- a/vividus/src/main/resources/log4j2.xml
+++ b/vividus/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.vividus.log">
+<Configuration status="WARN">
     <Appenders>
         <Console name="console">
             <PatternLayout pattern="%highlight{%d [%t] %-5p %c - %m%n}" />


### PR DESCRIPTION
Loading of Log4J2 plugins using package scanning is [deprecated]( https://logging.apache.org/log4j/2.x/release-notes/2.20.0.html#deprecated).
The only available option is [serialized plugin listing files](https://logging.apache.org/log4j/2.x/manual/plugins.html) on the classpath.
More details on deprecation: https://issues.apache.org/jira/browse/LOG4J2-3644.