### PR TITLE
[extension-selenium] Add ability to check WebDriver capabilities at cloud session link publishing

### DIFF
--- a/vividus-extension-selenium/src/main/java/org/vividus/selenium/WebDriverProvider.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/selenium/WebDriverProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class WebDriverProvider implements IWebDriverProvider
             String sessionId = WebDriverUtils.unwrap(webDriver, RemoteWebDriver.class).getSessionId().toString();
             try
             {
-                eventBus.post(new BeforeWebDriverQuitEvent());
+                eventBus.post(new BeforeWebDriverQuitEvent(sessionId));
                 webDriver.quit();
             }
             finally

--- a/vividus-extension-selenium/src/main/java/org/vividus/selenium/cloud/AbstractCloudTestLinkPublisher.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/selenium/cloud/AbstractCloudTestLinkPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vividus.reporter.event.LinkPublishEvent;
 import org.vividus.selenium.IWebDriverProvider;
-import org.vividus.selenium.event.AfterWebDriverQuitEvent;
+import org.vividus.selenium.event.BeforeWebDriverQuitEvent;
 import org.vividus.testcontext.TestContext;
 
 public abstract class AbstractCloudTestLinkPublisher
@@ -74,7 +74,7 @@ public abstract class AbstractCloudTestLinkPublisher
     }
 
     @Subscribe
-    public void publishCloudTestLinkOnWebDriverQuit(AfterWebDriverQuitEvent event)
+    public void publishCloudTestLinkOnWebDriverQuit(BeforeWebDriverQuitEvent event)
     {
         if (!getPublishState().isPublishedAfterScenario())
         {
@@ -87,7 +87,7 @@ public abstract class AbstractCloudTestLinkPublisher
         return testContext.get(KEY, CloudTestLinkPublishState.class);
     }
 
-    @SuppressWarnings("IllegalCatchExtended")
+    @SuppressWarnings({ "IllegalCatchExtended", "PMD.AvoidCatchingGenericException" })
     private void publishCloudTestLink(String sessionId)
     {
         try
@@ -104,7 +104,7 @@ public abstract class AbstractCloudTestLinkPublisher
         }
     }
 
-    private final class CloudTestLinkPublishState
+    private static final class CloudTestLinkPublishState
     {
         private boolean publishedAfterScenario;
 

--- a/vividus-extension-selenium/src/main/java/org/vividus/selenium/cloud/AbstractCloudTestStatusManager.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/selenium/cloud/AbstractCloudTestStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.vividus.selenium.cloud;
 
 import com.google.common.eventbus.Subscribe;
 
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vividus.selenium.IWebDriverProvider;
@@ -58,14 +57,14 @@ public abstract class AbstractCloudTestStatusManager
         }
     }
 
-    @SuppressWarnings("IllegalCatchExtended")
+    @SuppressWarnings({ "IllegalCatchExtended", "PMD.AvoidCatchingGenericException" })
     @Subscribe
     public final void updateCloudTestStatus(BeforeWebDriverQuitEvent event)
     {
         String status = getCloudTestStatus().isFailed() ? testStatusMapping.getFailed() : testStatusMapping.getPassed();
         try
         {
-            updateCloudTestStatus(status);
+            updateCloudTestStatus(event.getSessionId(), status);
         }
         catch (Exception e)
         {
@@ -84,14 +83,10 @@ public abstract class AbstractCloudTestStatusManager
         return testContext.get(KEY, CloudTestStatus::new);
     }
 
-    protected abstract void updateCloudTestStatus(String status) throws UpdateCloudTestStatusException;
+    protected abstract void updateCloudTestStatus(String sessionId, String status)
+            throws UpdateCloudTestStatusException;
 
-    protected String getSessionId()
-    {
-        return webDriverProvider.getUnwrapped(RemoteWebDriver.class).getSessionId().toString();
-    }
-
-    private final class CloudTestStatus
+    private static final class CloudTestStatus
     {
         private boolean failed;
 

--- a/vividus-extension-selenium/src/main/java/org/vividus/selenium/event/BeforeWebDriverQuitEvent.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/selenium/event/BeforeWebDriverQuitEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,4 +18,15 @@ package org.vividus.selenium.event;
 
 public class BeforeWebDriverQuitEvent
 {
+    private final String sessionId;
+
+    public BeforeWebDriverQuitEvent(String sessionId)
+    {
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionId()
+    {
+        return sessionId;
+    }
 }

--- a/vividus-extension-selenium/src/test/java/org/vividus/selenium/cloud/AbstractCloudTestLinkPublisherTests.java
+++ b/vividus-extension-selenium/src/test/java/org/vividus/selenium/cloud/AbstractCloudTestLinkPublisherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,9 +46,9 @@ import org.openqa.selenium.remote.SessionId;
 import org.vividus.reporter.event.LinkPublishEvent;
 import org.vividus.selenium.IWebDriverProvider;
 import org.vividus.selenium.cloud.AbstractCloudTestLinkPublisher.GetCloudTestUrlException;
-import org.vividus.selenium.event.AfterWebDriverQuitEvent;
+import org.vividus.selenium.event.BeforeWebDriverQuitEvent;
+import org.vividus.testcontext.SimpleTestContext;
 import org.vividus.testcontext.TestContext;
-import org.vividus.testcontext.ThreadedTestContext;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractCloudTestLinkPublisherTests
@@ -59,8 +59,8 @@ class AbstractCloudTestLinkPublisherTests
 
     @Mock private IWebDriverProvider webDriverProvider;
     @Mock private EventBus eventBus;
-    @Mock private AfterWebDriverQuitEvent webDriverQuitEvent;
-    @Spy private ThreadedTestContext testContext;
+    @Mock private BeforeWebDriverQuitEvent webDriverQuitEvent;
+    @Spy private SimpleTestContext testContext;
     @InjectMocks private TestCloudTestLinkPublisher linkPublisher;
 
     private final TestLogger logger = TestLoggerFactory.getTestLogger(AbstractCloudTestLinkPublisher.class);
@@ -114,8 +114,8 @@ class AbstractCloudTestLinkPublisherTests
         when(webDriverProvider.isWebDriverInitialized()).thenReturn(true);
         mockDriverSession();
 
-        GetCloudTestUrlException thrown = mock(GetCloudTestUrlException.class);
-        TestCloudTestLinkPublisher spy = spy(linkPublisher);
+        GetCloudTestUrlException thrown = mock();
+        var spy = spy(linkPublisher);
         doThrow(thrown).when(spy).getCloudTestUrl(SESSION_ID);
 
         spy.resetState();
@@ -127,8 +127,8 @@ class AbstractCloudTestLinkPublisherTests
 
     private void mockDriverSession()
     {
-        RemoteWebDriver remoteWebDriver = mock(RemoteWebDriver.class);
-        SessionId sessionId = mock(SessionId.class);
+        RemoteWebDriver remoteWebDriver = mock();
+        SessionId sessionId = mock();
 
         when(webDriverProvider.isWebDriverInitialized()).thenReturn(true);
         when(webDriverProvider.getUnwrapped(RemoteWebDriver.class)).thenReturn(remoteWebDriver);
@@ -140,7 +140,7 @@ class AbstractCloudTestLinkPublisherTests
     {
         verify(eventBus, times(times)).post(argThat(arg ->
         {
-            LinkPublishEvent event = (LinkPublishEvent) arg;
+            var event = (LinkPublishEvent) arg;
             return URL.equals(event.getUrl()) && "Test Test URL".equals(event.getName());
         }));
     }

--- a/vividus-plugin-browserstack/src/main/java/org/vividus/browserstack/BrowserStackTestStatusManager.java
+++ b/vividus-plugin-browserstack/src/main/java/org/vividus/browserstack/BrowserStackTestStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,11 @@ public class BrowserStackTestStatusManager extends AbstractCloudTestStatusManage
     }
 
     @Override
-    protected void updateCloudTestStatus(String status) throws UpdateCloudTestStatusException
+    protected void updateCloudTestStatus(String sessionId, String status) throws UpdateCloudTestStatusException
     {
         try
         {
-            browserStackAutomateClient.updateSessionStatus(getSessionId(), status);
+            browserStackAutomateClient.updateSessionStatus(sessionId, status);
         }
         catch (BrowserStackException e)
         {

--- a/vividus-plugin-browserstack/src/test/java/org/vividus/browserstack/BrowserStackTestStatusManagerTests.java
+++ b/vividus-plugin-browserstack/src/test/java/org/vividus/browserstack/BrowserStackTestStatusManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.browserstack.client.exception.BrowserStackException;
 
@@ -30,9 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.SessionId;
-import org.vividus.selenium.IWebDriverProvider;
 import org.vividus.selenium.cloud.AbstractCloudTestStatusManager.UpdateCloudTestStatusException;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,16 +37,13 @@ class BrowserStackTestStatusManagerTests
     private static final String SESSION_ID = "session-id";
     private static final String STATUS = "status";
 
-    @Mock private IWebDriverProvider webDriverProvider;
     @Mock private BrowserStackAutomateClient appAutomateClient;
     @InjectMocks private BrowserStackTestStatusManager manager;
 
     @Test
     void shouldUpdateCloudTestStatus() throws BrowserStackException, UpdateCloudTestStatusException
     {
-        mockSessionId();
-
-        manager.updateCloudTestStatus(STATUS);
+        manager.updateCloudTestStatus(SESSION_ID, STATUS);
 
         verify(appAutomateClient).updateSessionStatus(SESSION_ID, STATUS);
     }
@@ -58,24 +51,13 @@ class BrowserStackTestStatusManagerTests
     @Test
     void shouldWrapBrowserStackException() throws BrowserStackException
     {
-        mockSessionId();
-        BrowserStackException browserStackException = mock(BrowserStackException.class);
+        BrowserStackException browserStackException = mock();
 
         doThrow(browserStackException).when(appAutomateClient).updateSessionStatus(SESSION_ID, STATUS);
 
-        UpdateCloudTestStatusException thrown = assertThrows(UpdateCloudTestStatusException.class,
-            () -> manager.updateCloudTestStatus(STATUS));
+        var thrown = assertThrows(UpdateCloudTestStatusException.class,
+            () -> manager.updateCloudTestStatus(SESSION_ID, STATUS));
 
         assertEquals(browserStackException, thrown.getCause());
-    }
-
-    private void mockSessionId()
-    {
-        RemoteWebDriver remoteWebDriver = mock(RemoteWebDriver.class);
-        SessionId sessionId = mock(SessionId.class);
-
-        when(webDriverProvider.getUnwrapped(RemoteWebDriver.class)).thenReturn(remoteWebDriver);
-        when(remoteWebDriver.getSessionId()).thenReturn(sessionId);
-        when(sessionId.toString()).thenReturn(SESSION_ID);
     }
 }

--- a/vividus-plugin-crossbrowsertesting/src/main/java/org/vividus/crossbrowsertesting/CbtTestStatusManager.java
+++ b/vividus-plugin-crossbrowsertesting/src/main/java/org/vividus/crossbrowsertesting/CbtTestStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,11 @@ public class CbtTestStatusManager extends AbstractCloudTestStatusManager
     }
 
     @Override
-    protected void updateCloudTestStatus(String status) throws UpdateCloudTestStatusException
+    protected void updateCloudTestStatus(String sessionId, String status) throws UpdateCloudTestStatusException
     {
         try
         {
-            new AutomatedTest(getSessionId()).setScore(status);
+            new AutomatedTest(sessionId).setScore(status);
         }
         catch (UnirestException exception)
         {

--- a/vividus-plugin-lambdatest/src/main/java/org/vividus/lambdatest/LambdaTestTestStatusManager.java
+++ b/vividus-plugin-lambdatest/src/main/java/org/vividus/lambdatest/LambdaTestTestStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class LambdaTestTestStatusManager extends AbstractCloudTestStatusManager
     }
 
     @Override
-    protected void updateCloudTestStatus(String status) throws UpdateCloudTestStatusException
+    protected void updateCloudTestStatus(String sessionId, String status) throws UpdateCloudTestStatusException
     {
         javascriptActions.executeScript("lambda-status=" + status);
     }

--- a/vividus-plugin-lambdatest/src/test/java/org/vividus/lambdatest/LambdaTestTestStatusManagerTests.java
+++ b/vividus-plugin-lambdatest/src/test/java/org/vividus/lambdatest/LambdaTestTestStatusManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class LambdaTestTestStatusManagerTests
     @Test
     void shouldUpdateSessionStatus() throws UpdateCloudTestStatusException
     {
-        manager.updateCloudTestStatus("status");
+        manager.updateCloudTestStatus(null, "status");
 
         verify(javascriptActions).executeScript("lambda-status=status");
         verifyNoMoreInteractions(javascriptActions);

--- a/vividus-plugin-saucelabs/src/main/java/org/vividus/saucelabs/SauceLabsTestStatusManager.java
+++ b/vividus-plugin-saucelabs/src/main/java/org/vividus/saucelabs/SauceLabsTestStatusManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class SauceLabsTestStatusManager extends AbstractCloudTestStatusManager
     }
 
     @Override
-    protected void updateCloudTestStatus(String status) throws UpdateCloudTestStatusException
+    protected void updateCloudTestStatus(String sessionId, String status) throws UpdateCloudTestStatusException
     {
         javascriptActions.executeScript("sauce:job-result=" + status);
     }

--- a/vividus-plugin-saucelabs/src/test/java/org/vividus/saucelabs/SauceLabsTestStatusManagerTests.java
+++ b/vividus-plugin-saucelabs/src/test/java/org/vividus/saucelabs/SauceLabsTestStatusManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class SauceLabsTestStatusManagerTests
     @Test
     void shouldUpdateSessionStatus() throws UpdateCloudTestStatusException
     {
-        manager.updateCloudTestStatus("status");
+        manager.updateCloudTestStatus(null, "status");
 
         verify(javascriptActions).executeScript("sauce:job-result=status");
         verifyNoMoreInteractions(javascriptActions);


### PR DESCRIPTION
The capabilities attempted to get by SauceLabs plugin after WebDriver quit are unavailable, such attempts leads to start of invalid sessions.

<img width="1533" alt="sl-error" src="https://user-images.githubusercontent.com/5081226/231485659-0b559139-47ea-40c8-a303-8609e6fa742f.png">
