### PR TITLE
[plugin-saucelabs] Remove usage of `mockito-inline` dependency

### DIFF
--- a/vividus-plugin-saucelabs/build.gradle
+++ b/vividus-plugin-saucelabs/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     testCompileOnly(group: 'junit', name: 'junit', version: '4.13.2')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.2.0')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
-    testImplementation(group: 'org.mockito', name: 'mockito-inline')
     testImplementation(group: 'com.github.powermock.powermock', name: 'powermock-api-mockito2', version: versions.powermock)
     testImplementation(group: 'com.github.powermock.powermock', name: 'powermock-module-junit4', version: versions.powermock)
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.9.0')

--- a/vividus-plugin-saucelabs/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/vividus-plugin-saucelabs/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
As of Mockito 5.0.0 the default mockmaker was switched to `mockito-inline`: https://github.com/mockito/mockito/releases/tag/v5.0.0