### PR TITLE
[plugin-web-app] Switch back to default HTTP client for Selenium

### DIFF
--- a/vividus-plugin-web-app/build.gradle
+++ b/vividus-plugin-web-app/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation(group: 'org.seleniumhq.selenium', name: 'selenium-firefox-driver')
     implementation(group: 'org.seleniumhq.selenium', name: 'selenium-ie-driver')
     implementation(group: 'org.seleniumhq.selenium', name: 'selenium-safari-driver')
-    implementation(group: 'org.seleniumhq.selenium', name: 'selenium-http-jdk-client')
     implementation(group: 'junit', name: 'junit', version: '4.13.2')
     implementation(group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.3.2') {
         exclude group: 'com.github.docker-java'

--- a/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
+++ b/vividus-plugin-web-app/src/main/resources/properties/profile/web/profile.properties
@@ -43,7 +43,3 @@ selenium.screenshot.full-page=true
 selenium.screenshot.indent=300
 # highlighter types: DEFAULT, BLUR, MONOCHROME
 selenium.screenshot.highlighter=DEFAULT
-
-# https://www.selenium.dev/blog/2022/using-java11-httpclient/#integrating-the-java-11-client
-# Reason: https://github.com/SeleniumHQ/selenium/issues/11750
-system.webdriver.http.factory=jdk-http-client


### PR DESCRIPTION
Reason: mobile web tests (e.g. iPad) fail on SauceLabs.
Assumption: regression issue was introduced in Selenium 4.9.0 (possible root cause: https://github.com/SeleniumHQ/selenium/pull/11816)