### PR TITLE
[util] Switch to use non-deprecated Jackson API for exact `BigDecimal`-s

### DIFF
--- a/vividus-util/src/main/java/org/vividus/util/json/JsonPathUtils.java
+++ b/vividus-util/src/main/java/org/vividus/util/json/JsonPathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -81,8 +81,8 @@ public final class JsonPathUtils
 
         static
         {
-            OBJECT_MAPPER.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
-            OBJECT_MAPPER.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+            OBJECT_MAPPER.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+                    .configure(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES, false);
         }
 
         private final JsonProvider jacksonJsonProvider = new JacksonJsonProvider(OBJECT_MAPPER);


### PR DESCRIPTION
See: https://github.com/FasterXML/jackson-databind/issues/3651