### PR TITLE
[docker-bundler] Skip packing of Applitools plugin due to its huge size

### DIFF
--- a/vividus-docker-bundler/build.gradle
+++ b/vividus-docker-bundler/build.gradle
@@ -13,7 +13,10 @@ tasks {
 dependencies {
     implementation project(':vividus')
     implementation project(':vividus-plugin-accessibility')
-    implementation project(':vividus-plugin-applitools')
+
+    // https://github.com/applitools/eyes.sdk.java3/issues/591
+    // implementation project(':vividus-plugin-applitools')
+
     implementation project(':vividus-plugin-avro')
     implementation project(':vividus-plugin-aws-dynamodb')
     implementation project(':vividus-plugin-aws-kinesis')


### PR DESCRIPTION
Applitools issue: https://github.com/applitools/eyes.sdk.java3/issues/591