### PR TITLE
[plugin-saucelabs] Enable back support of the latest SauceConnect 

### DIFF
--- a/vividus-extension-selenium/src/main/java/org/vividus/selenium/tunnel/TunnelOptions.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/selenium/tunnel/TunnelOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,17 +45,17 @@ public class TunnelOptions
     }
 
     @Override
-    public boolean equals(Object obj)
+    public boolean equals(Object o)
     {
-        if (this == obj)
+        if (this == o)
         {
             return true;
         }
-        if (!(obj instanceof TunnelOptions))
+        if (o == null || getClass() != o.getClass())
         {
             return false;
         }
-        TunnelOptions other = (TunnelOptions) obj;
-        return Objects.equals(proxy, other.proxy);
+        TunnelOptions that = (TunnelOptions) o;
+        return Objects.equals(proxy, that.proxy);
     }
 }

--- a/vividus-plugin-saucelabs/build.gradle
+++ b/vividus-plugin-saucelabs/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     testImplementation(group: 'com.github.powermock.powermock', name: 'powermock-api-mockito2', version: versions.powermock)
     testImplementation(group: 'com.github.powermock.powermock', name: 'powermock-module-junit4', version: versions.powermock)
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '2.9.0')
+    testImplementation(group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.14.3')
 }

--- a/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurer.java
+++ b/vividus-plugin-saucelabs/src/main/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurer.java
@@ -28,14 +28,16 @@ public class SauceLabsCapabilitiesConfigurer extends AbstractTunnellingCapabilit
 {
     private static final String SAUCE_OPTIONS = "sauce:options";
 
+    private final boolean useLatestSauceConnect;
     private final String restUrl;
     private String sauceConnectArguments;
     private Set<String> skipHostGlobPatterns;
 
-    public SauceLabsCapabilitiesConfigurer(RunContext runContext, SauceConnectManager sauceConnectManager,
-            DataCenter dataCenter)
+    public SauceLabsCapabilitiesConfigurer(boolean useLatestSauceConnect, RunContext runContext,
+            SauceConnectManager sauceConnectManager, DataCenter dataCenter)
     {
         super(runContext, sauceConnectManager);
+        this.useLatestSauceConnect = useLatestSauceConnect;
         this.restUrl = dataCenter.apiServer() + "rest/v1";
     }
 
@@ -51,7 +53,7 @@ public class SauceLabsCapabilitiesConfigurer extends AbstractTunnellingCapabilit
     @Override
     protected SauceConnectOptions createOptions()
     {
-        return new SauceConnectOptions(restUrl, sauceConnectArguments,
+        return new SauceConnectOptions(useLatestSauceConnect, restUrl, sauceConnectArguments,
                 skipHostGlobPatterns == null ? Set.of() : skipHostGlobPatterns);
     }
 

--- a/vividus-plugin-saucelabs/src/main/resources/vividus-plugin/spring.xml
+++ b/vividus-plugin-saucelabs/src/main/resources/vividus-plugin/spring.xml
@@ -27,6 +27,7 @@
     <bean class="org.vividus.saucelabs.SauceLabsTestStatusManager" lazy-init="false"/>
 
     <bean class="org.vividus.selenium.sauce.SauceLabsCapabilitiesConfigurer">
+        <constructor-arg index="0" value="${saucelabs.sauce-connect.use-latest-version}" />
         <property name="tunnellingEnabled" value="${saucelabs.sauce-connect.enabled}"/>
         <property name="sauceConnectArguments" value="${saucelabs.sauce-connect.command-line-arguments}" />
         <property name="skipHostGlobPatterns" value="${saucelabs.sauce-connect.skip-host-glob-patterns}" />

--- a/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceConnectOptionsTests.java
+++ b/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceConnectOptionsTests.java
@@ -17,7 +17,6 @@
 package org.vividus.selenium.sauce;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -27,9 +26,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Set;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.vividus.util.ResourceUtils;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class SauceConnectOptionsTests
 {
@@ -73,6 +75,22 @@ class SauceConnectOptionsTests
 
             assertEquals(TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + pacPath + SPACE
                     + TUNNEL_POOL, sauceConnectOptions.build(TUNNEL_NAME));
+        }
+    }
+
+    @Test
+    void testBuildWithProxyForLatestSauceConnect() throws IOException
+    {
+        SauceConnectOptions sauceConnectOptions = new SauceConnectOptions(true, null, null, Set.of());
+        sauceConnectOptions.setProxy(PROXY);
+        try (MockedStatic<ResourceUtils> resources = mockStatic(ResourceUtils.class))
+        {
+            Path pacPath = mockPac(resources, DEFAULT_MATCH_CHAIN);
+            Path pidPath = mockPid(resources);
+
+            assertEquals(TUNNEL_NAME_OPTION + SPACE + PID_FILE + SPACE + pidPath + SPACE + PAC_FILE + (
+                            SystemUtils.IS_OS_WINDOWS ? "/" : "") + pacPath + SPACE + TUNNEL_POOL,
+                    sauceConnectOptions.build(TUNNEL_NAME));
         }
     }
 
@@ -173,9 +191,12 @@ class SauceConnectOptionsTests
     }
 
     @Test
-    void testNotEqualsToNull()
+    void verifyHashCodeAndEquals()
     {
-        assertFalse(createDefaultOptions().equals(null));
+        EqualsVerifier.simple().forClass(SauceConnectOptions.class)
+                .withRedefinedSuperclass()
+                .withIgnoredFields("customArguments")
+                .verify();
     }
 
     @Test
@@ -212,7 +233,7 @@ class SauceConnectOptionsTests
     private SauceConnectOptions createOptions(String restUrl, String customArguments, Set<String> skipHostGlobPatterns,
             String proxy)
     {
-        SauceConnectOptions options = new SauceConnectOptions(restUrl, customArguments, skipHostGlobPatterns);
+        SauceConnectOptions options = new SauceConnectOptions(false, restUrl, customArguments, skipHostGlobPatterns);
         options.setProxy(proxy);
         return options;
     }

--- a/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurerTests.java
+++ b/vividus-plugin-saucelabs/src/test/java/org/vividus/selenium/sauce/SauceLabsCapabilitiesConfigurerTests.java
@@ -71,7 +71,7 @@ class SauceLabsCapabilitiesConfigurerTests
     @BeforeEach
     void beforeEach()
     {
-        configurer = new SauceLabsCapabilitiesConfigurer(runContext, sauceConnectManager, DataCenter.EU_CENTRAL);
+        configurer = new SauceLabsCapabilitiesConfigurer(true, runContext, sauceConnectManager, DataCenter.EU_CENTRAL);
     }
 
     @Test
@@ -99,7 +99,7 @@ class SauceLabsCapabilitiesConfigurerTests
         configurer.setTunnellingEnabled(true);
         Map<String, Object> sauceOptions = new HashMap<>();
         var desiredCapabilities = mockDesiredCapabilities(null, sauceOptions);
-        var sauceConnectOptions = new SauceConnectOptions(REST_URL, null, Set.of());
+        var sauceConnectOptions = new SauceConnectOptions(true, REST_URL, null, Set.of());
         when(sauceConnectManager.start(sauceConnectOptions)).thenReturn(TUNNEL_NAME);
 
         configurer.configure(desiredCapabilities);
@@ -118,7 +118,7 @@ class SauceLabsCapabilitiesConfigurerTests
         var httpProxy = "http-proxy:8080";
         when(proxy.getHttpProxy()).thenReturn(httpProxy);
 
-        var sauceConnectOptions = new SauceConnectOptions(REST_URL, CUSTOM_ARGS, SKIP_HOST_GLOB_PATTERNS);
+        var sauceConnectOptions = new SauceConnectOptions(true, REST_URL, CUSTOM_ARGS, SKIP_HOST_GLOB_PATTERNS);
         sauceConnectOptions.setProxy(httpProxy);
 
         Map<String, Object> sauceOptions = new HashMap<>();
@@ -146,7 +146,7 @@ class SauceLabsCapabilitiesConfigurerTests
     {
         configurer.setSauceConnectArguments(CUSTOM_ARGS);
         configurer.setSkipHostGlobPatterns(setValue);
-        assertEquals(new SauceConnectOptions(REST_URL, CUSTOM_ARGS, expectedValue), configurer.createOptions());
+        assertEquals(new SauceConnectOptions(true, REST_URL, CUSTOM_ARGS, expectedValue), configurer.createOptions());
     }
 
     private void mockRunningStory()

--- a/vividus-tests/src/main/resources/properties/environment/system/saucelabs/environment.properties
+++ b/vividus-tests/src/main/resources/properties/environment/system/saucelabs/environment.properties
@@ -1,7 +1,2 @@
 selenium.grid.host=ondemand.eu-central-1.saucelabs.com
 saucelabs.data-center=EU
-
-# SauceLabs released a new version of SauceConnect (4.9.0):
-# https://changelog.saucelabs.com/en/sauce-connect-proxy-release-version-490-aec8wD1P
-# System tests has started failing. Need to investigate, but temporary disabling latest SC
-saucelabs.sauce-connect.use-latest-version=false


### PR DESCRIPTION
SauceConnect 4.9.1 is released with fixes of SSL bugs (https://changelog.saucelabs.com/en/sauce-connect-proxy-release-version-491):
Bug Fixes
 - Fixed a bug to allow https access when SSL bumping is disabled
 - Fixed a bug to allow self-signed certificates when SSL bumping is enabled