### PR TITLE
[docs] Remove SauceLabs Data center `APAC_SOUTHEAST`

### DIFF
--- a/docs/modules/plugins/pages/plugin-sauce-labs.adoc
+++ b/docs/modules/plugins/pages/plugin-sauce-labs.adoc
@@ -74,7 +74,6 @@ a|
 * `US_WEST` +
 * `US_EAST` +
 * `EU_CENTRAL` +
-* `APAC_SOUTHEAST`
 
 [WARNING]
 ====


### PR DESCRIPTION
It seems SauceLabs silently decommissioned APAC data center: https://docs.saucelabs.com/basics/data-center-endpoints/