### PR TITLE
Migrate to new instance of VIVIDUS test site

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -74,7 +74,7 @@ jobs:
         java-version: 17
 
     - name: Warm up VIVIDUS test site
-      run: curl https://vividus-test-site.onrender.com/ &
+      run: curl https://vividus-test-site-a92k.onrender.com/ &
 
     - name: Build
       env:

--- a/docs/modules/plugins/pages/plugin-accessibility.adoc
+++ b/docs/modules/plugins/pages/plugin-accessibility.adoc
@@ -49,7 +49,7 @@ Accessibility test options:
 .Check page against WCAG 2.2 Level AA
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 When I perform accessibility scan:
 |standard|
 |WCAG22AA|
@@ -58,7 +58,7 @@ When I perform accessibility scan:
 .Check video elements against no-autoplay-audio and video-caption rules
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 When I perform accessibility scan:
 |violationsToCheck              |elementsToCheck|
 |no-autoplay-audio,video-caption|tagName(video) |
@@ -96,7 +96,7 @@ The step based on the contextual approach and when it's necessary it could be us
 .Check accessibility
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 When I change context to element located by `xpath(//body)`
 When I perform accessibility scan:
 |standard|level |elementsToIgnore                                 |elementsToCheck|violationsToIgnore                                                                     |

--- a/docs/modules/plugins/pages/plugin-rest-api.adoc
+++ b/docs/modules/plugins/pages/plugin-rest-api.adoc
@@ -362,7 +362,7 @@ a|
 When I set HTTP request configuration:
 |socketTimeout |
 |25000         |
-When I execute HTTP GET request for resource with URL `https://vividus-test-site.onrender.com/?pageTimeout=20000`
+When I execute HTTP GET request for resource with URL `https://vividus-test-site-a92k.onrender.com/?pageTimeout=20000`
 Then '${responseStatusCode}' is = '200'
 ----
 
@@ -786,7 +786,7 @@ Then server `$hostname` supports secure protocols that $rule `$protocols`
 .Validate the server supports TLSv1.2 and TLSv1.3 protocols
 [source,gherkin]
 ----
-Then server `vividus-test-site.onrender.com` supports secure protocols that contain `TLSv1.2,TLSv1.3`
+Then server `vividus-test-site-a92k.onrender.com` supports secure protocols that contain `TLSv1.2,TLSv1.3`
 ----
 
 === Wait for expected HTTP status code in response
@@ -906,9 +906,9 @@ Then HTTP resources are valid:$resources
 [source,gherkin]
 ----
 Then HTTP resources are valid:
-|url                                                   |
-|https://saucelabs.com                                 |
-|https://vividus-test-site.onrender.com/img/vividus.png|
+| url                                                         |
+| https://saucelabs.com                                       |
+| https://vividus-test-site-a92k.onrender.com/img/vividus.png |
 ----
 
 

--- a/docs/modules/plugins/pages/plugin-web-app.adoc
+++ b/docs/modules/plugins/pages/plugin-web-app.adoc
@@ -197,7 +197,7 @@ When I wait `$duration` until window with title that $comparisonRule `$windowTit
 .Wait for tab and switch to it
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/windows.html`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/windows.html`
 When I click on element located by `id(timeout)`
 When I wait `PT3S` until tab with title that is equal to `Vividus test site` appears and switch to it
 ----

--- a/docs/modules/plugins/partials/generic-ui-steps.adoc
+++ b/docs/modules/plugins/partials/generic-ui-steps.adoc
@@ -591,7 +591,7 @@ When I execute javascript `$jsCode` and save result to $scopes variable `$variab
 .Validate timings
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 When I execute javascript `return JSON.stringify(window.performance.timing)` and save result to scenario variable `timings`
 Then number of JSON elements from `${timings}` by JSON path `$.connectStart` is = 1
 ----

--- a/docs/modules/plugins/partials/plugin-web-app-steps.adoc
+++ b/docs/modules/plugins/partials/plugin-web-app-steps.adoc
@@ -578,7 +578,7 @@ Then there are no browser console $logLevels
 .Validate absence of JS errors
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 Then there are no browser console ERRORS
 ----
 
@@ -603,7 +603,7 @@ Then there are no browser console $logLevels by regex '$regex'
 .Validate absence of JS error referencing user
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 Then there are no browser console ERRORS by regex `.*user.*`
 ----
 
@@ -621,7 +621,7 @@ Then there are browser console $logLevels by regex `$regex`
 .Validate presence of JS errors referencing user
 [source,gherkin]
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 Then there are browser console ERRORS by regex `.*user.*`
 ----
 
@@ -642,7 +642,7 @@ When I wait until browser console $logEntries by regex `$regex` appear and save 
 
 .Wait for application readiness
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/`
 When I wait until browser console infos by regex `.*Application ready.*` appear and save all entries into scenario variable `logs`
 Then `${logs}` matches `.*Application ready in \d+ seconds.*`
 ----
@@ -692,7 +692,7 @@ When I switch back to the page
 
 .Switch to user context and back to the default context of page
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/elementState.html`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/elementState.html`
 When I change context to element located by `id(button-hide)`
 Then text `Element to hide` does not exist
 When I switch back to the page
@@ -711,7 +711,7 @@ When I switch to frame located `$locator`
 
 .Switch to frame
 ----
-Given I am on page with URL `https://vividus-test-site.onrender.com/nestedFrames.html`
+Given I am on page with URL `https://vividus-test-site-a92k.onrender.com/nestedFrames.html`
 Then text `Modal Frame Example` does not exist
 When I switch to frame located `id(parent)`
 Then text `Modal Frame Example` exists

--- a/vividus-tests/src/main/resources/properties/environment/environment.properties
+++ b/vividus-tests/src/main/resources/properties/environment/environment.properties
@@ -1,4 +1,4 @@
-variables.vividus-test-site-host=vividus-test-site.onrender.com
+variables.vividus-test-site-host=vividus-test-site-a92k.onrender.com
 variables.vividus-test-site-url=https://${variables.vividus-test-site-host}
 
 variables.screenshot-directory=${output.directory}/screenshots


### PR DESCRIPTION
VIVIDUS test site service was moved from Team to Invidiual account, thus new subdomain was generated. It's not possible to define own subdomain: https://community.render.com/t/can-i-change-my-existing-subdomain-onrender-com-to-a-new-one/9999/2. Full notification from Render:

> Hi there,
> 
> We're reaching out to remind you of upcoming changes to your Render bill. Single-user teams created before January 2023 received a 6-month grace period during which they did not have to pay $19 per user per month.
> 
> Starting July 1, 2023, your team VIVIDUS will be charged $19 per user per month starting July 2023. Active Render teams will be charged $19 per user per month in addition to compute costs.
> 
> If you do not need the additional features in the Team plan, you can recreate your services in your individual account or suspend unused services on your Team before June 30, 2023 to avoid the monthly fee. As a reminder, teams that do not have any active services for the entire month will not be charged a per-user fee.
> 
> If you wish to continue running your services on your team, no action is needed.
> 
> We're here to help. Please reply to this email if you'd like assistance or have questions.
> 
> Best,
> 
> The Render Team