### PR TITLE
[docker-bundler] Add `glibc` library to Docker image

### DIFF
--- a/vividus-docker-bundler/build.gradle
+++ b/vividus-docker-bundler/build.gradle
@@ -87,6 +87,7 @@ task createDockerfile(type: Dockerfile) {
 
     from('eclipse-temurin:17-jre-alpine')
     label(['maintainer': 'Vividus Team "vividus.team@vividus.dev"'])
+    instruction('RUN apk add gcompat')
     workingDir('vividus')
     copyFile('libs', 'libs/')
     entryPoint('java', '-cp', '/vividus/resources:/vividus/libs/*', 'org.vividus.runner.StoriesRunner')


### PR DESCRIPTION
https://support.saucelabs.com/hc/en-us/articles/10075350509079-Using-Alpine-OS-with-Sauce-Connect:

Sauce Connect requires glibc, a library of tools available in most GNU/Linux systems. Alpine is not one of those and requires extra configuration to ensure your Sauce Connect tunnel can be used.