### PR TITLE
[plugin-visual] Remove deprecated non-unified definitions of cut strategies for mobile apps

### DIFF
--- a/docs/modules/plugins/pages/plugin-visual.adoc
+++ b/docs/modules/plugins/pages/plugin-visual.adoc
@@ -268,14 +268,6 @@ where:
 |Acceptable values
 |Description
 
-|`mobile.screenshot.strategy.<YOUR_STRATEGY_NAME>.native-footer-to-cut`
-|size in pixels
-a|Native footer to cut.
-[WARNING]
-====
-This property is deprecated and will be removed in VIVIDUS 0.6.0. Use `mobile.screenshot.strategy.<YOUR_STRATEGY_NAME>.cut-bottom` property instead.
-====
-
 |`mobile.screenshot.strategy.<YOUR_STRATEGY_NAME>.cut-top`
 |size in pixels
 |The size of top part of the final screenshot to cut.
@@ -310,7 +302,6 @@ The shooting strategy `SIMPLE` is deprecated and will be removed in VIVIDUS 0.6.
 
 [source,gherkin]
 ----
-mobile.screenshot.strategy.bombaysapphire.native-footer-to-cut=100
 mobile.screenshot.strategy.custom.cut-top=100
 mobile.screenshot.strategy.custom.cut-left=100
 mobile.screenshot.strategy.custom.cut-right=100

--- a/vividus-extension-selenium/src/main/java/org/vividus/ui/screenshot/ScreenshotConfiguration.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/ui/screenshot/ScreenshotConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,35 +27,10 @@ public class ScreenshotConfiguration
     private int cutBottom;
     private int cutLeft;
     private int cutRight;
-    /**
-     * @deprecated use {@link ScreenshotConfiguration#cutTop} instead.
-     */
-    @Deprecated(since = "0.4.16", forRemoval = true)
-    private int nativeFooterToCut;
 
     private Optional<String> shootingStrategy = Optional.empty();
     private Set<Locator> elementsToIgnore = Set.of();
     private Set<Locator> areasToIgnore = Set.of();
-
-    /**
-     * @deprecated use {@link ScreenshotConfiguration#getCutTop()} instead.
-     * @return Native footer to cut.
-     */
-    @Deprecated(since = "0.4.16", forRemoval = true)
-    public int getNativeFooterToCut()
-    {
-        return nativeFooterToCut;
-    }
-
-    /**
-     * @deprecated use {@link ScreenshotConfiguration#setCutTop(int)} instead.
-     * @param nativeFooterToCut The native footer to cut in pixels.
-     */
-    @Deprecated(since = "0.4.16", forRemoval = true)
-    public void setNativeFooterToCut(int nativeFooterToCut)
-    {
-        this.nativeFooterToCut = nativeFooterToCut;
-    }
 
     public int getCutTop()
     {

--- a/vividus-extension-selenium/src/test/java/org/vividus/converter/ui/AbstractExamplesTableToScreenshotConfigurationConverterTests.java
+++ b/vividus-extension-selenium/src/test/java/org/vividus/converter/ui/AbstractExamplesTableToScreenshotConfigurationConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.vividus.converter.ui;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 
 import org.jbehave.core.model.ExamplesTable;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.vividus.ui.screenshot.ScreenshotConfiguration;
 import org.vividus.ui.screenshot.ScreenshotParameters;
@@ -33,19 +33,21 @@ class AbstractExamplesTableToScreenshotConfigurationConverterTests
         new TestExamplesTableToScreenshotConfigurationConverter();
 
     @Test
-    void shouldConvertExamplesTableToScreenshotConfiguraiton()
+    void shouldConvertExamplesTableToScreenshotConfiguration()
     {
-        ExamplesTable table = new ExamplesTable("|nativeFooterToCut|\n|101|");
-        ScreenshotConfiguration configuration = CONVERTER.convertValue(table, ScreenshotConfiguration.class);
-        Assertions.assertAll(() -> assertEquals(Optional.empty(), configuration.getShootingStrategy()),
-                             () -> assertEquals(101, configuration.getNativeFooterToCut()));
+        var table = new ExamplesTable("|cutBottom|\n|101|");
+        var configuration = CONVERTER.convertValue(table, ScreenshotConfiguration.class);
+        assertAll(
+                () -> assertEquals(Optional.empty(), configuration.getShootingStrategy()),
+                () -> assertEquals(101, configuration.getCutBottom())
+        );
     }
 
     @Test
     void shouldThrowAnException()
     {
-        ExamplesTable table = new ExamplesTable("|nativeFooterToCut|\n|101|\n|102|");
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        var table = new ExamplesTable("|cutBottom|\n|101|\n|102|");
+        var exception = assertThrows(IllegalArgumentException.class,
             () -> CONVERTER.convertValue(table, ScreenshotParameters.class));
         assertEquals("Only one row is acceptable for screenshot configurations", exception.getMessage());
     }

--- a/vividus-extension-selenium/src/test/java/org/vividus/ui/screenshot/AbstractScreenshotParametersFactoryTests.java
+++ b/vividus-extension-selenium/src/test/java/org/vividus/ui/screenshot/AbstractScreenshotParametersFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ class AbstractScreenshotParametersFactoryTests
         configuration.setElementsToIgnore(Set.of(stepElementLocator));
         configuration.setAreasToIgnore(Set.of(stepAreaLocator));
         configuration.setShootingStrategy(Optional.of(DEFAULT));
-        configuration.setNativeFooterToCut(1);
+        configuration.setCutBottom(1);
 
         var globalElementLocator = mock(Locator.class);
         var globalAreaLocator = mock(Locator.class);
@@ -193,10 +193,10 @@ class AbstractScreenshotParametersFactoryTests
     @Test
     void shouldCreateParametersFromDefaultConfiguration()
     {
-        var nativeFooterToCut = 5;
+        var cutBottom = 5;
 
         factory.setScreenshotConfigurations(
-                new PropertyMappedCollection<>(Map.of(DEFAULT, createConfiguration(nativeFooterToCut))));
+                new PropertyMappedCollection<>(Map.of(DEFAULT, createConfiguration(cutBottom))));
         factory.setShootingStrategy(DEFAULT);
         factory.setIgnoreStrategies(createEmptyIgnores());
 

--- a/vividus-plugin-mobile-app/src/main/java/org/vividus/mobileapp/converter/ExamplesTableToScreenshotConfigurationConverter.java
+++ b/vividus-plugin-mobile-app/src/main/java/org/vividus/mobileapp/converter/ExamplesTableToScreenshotConfigurationConverter.java
@@ -16,33 +16,14 @@
 
 package org.vividus.mobileapp.converter;
 
-import java.lang.reflect.Type;
-
-import org.jbehave.core.model.ExamplesTable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.vividus.converter.ui.AbstractExamplesTableToScreenshotConfigurationConverter;
 import org.vividus.ui.screenshot.ScreenshotConfiguration;
 
 public class ExamplesTableToScreenshotConfigurationConverter
         extends AbstractExamplesTableToScreenshotConfigurationConverter<ScreenshotConfiguration>
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExamplesTableToScreenshotConfigurationConverter.class);
-
     protected ExamplesTableToScreenshotConfigurationConverter()
     {
         super(ScreenshotConfiguration.class);
-    }
-
-    @Override
-    public ScreenshotConfiguration convertValue(ExamplesTable value, Type type)
-    {
-        ScreenshotConfiguration screenshotConfiguration = super.convertValue(value, type);
-        if (screenshotConfiguration.getNativeFooterToCut() != 0)
-        {
-            LOGGER.atWarn().log("Screenshot configuration `nativeFooterToCut` is deprecated, use `cutBottom` instead.");
-            screenshotConfiguration.setCutBottom(screenshotConfiguration.getNativeFooterToCut());
-        }
-        return screenshotConfiguration;
     }
 }

--- a/vividus-plugin-mobile-app/src/main/resources/properties/deprecated/deprecated.properties
+++ b/vividus-plugin-mobile-app/src/main/resources/properties/deprecated/deprecated.properties
@@ -1,1 +1,0 @@
-mobile\.screenshot\.strategy\.([^.]+)\.native-footer-to-cut=mobile.screenshot.strategy.$1.cut-bottom

--- a/vividus-plugin-mobile-app/src/test/java/org/vividus/mobileapp/converter/ExamplesTableToScreenshotConfigurationConverterTests.java
+++ b/vividus-plugin-mobile-app/src/test/java/org/vividus/mobileapp/converter/ExamplesTableToScreenshotConfigurationConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,49 +16,26 @@
 
 package org.vividus.mobileapp.converter;
 
-import static com.github.valfirst.slf4jtest.LoggingEvent.warn;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
 import java.util.Optional;
 
-import com.github.valfirst.slf4jtest.TestLogger;
-import com.github.valfirst.slf4jtest.TestLoggerFactory;
-import com.github.valfirst.slf4jtest.TestLoggerFactoryExtension;
-
 import org.jbehave.core.model.ExamplesTable;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.vividus.ui.screenshot.ScreenshotConfiguration;
 import org.vividus.ui.screenshot.ScreenshotParameters;
 
-@ExtendWith(TestLoggerFactoryExtension.class)
 class ExamplesTableToScreenshotConfigurationConverterTests
 {
-    private static final TestLogger LOGGER
-        = TestLoggerFactory.getTestLogger(ExamplesTableToScreenshotConfigurationConverter.class);
-
     @Test
     void shouldConvertExamplesTableToScreenshotConfiguration()
     {
-        ExamplesTable table = new ExamplesTable("|cutTop|\n|101|");
-        ScreenshotConfiguration screenshotConfiguration = new ExamplesTableToScreenshotConfigurationConverter()
+        var table = new ExamplesTable("|cutTop|\n|101|");
+        var screenshotConfiguration = new ExamplesTableToScreenshotConfigurationConverter()
                 .convertValue(table, ScreenshotParameters.class);
-        Assertions.assertAll(() -> assertEquals(Optional.empty(), screenshotConfiguration.getShootingStrategy()),
-                             () -> assertEquals(101, screenshotConfiguration.getCutTop()));
-    }
-
-    @Test
-    void shouldNotifyAboutDeprecatedFieldAndReuseValueInNonReplacement()
-    {
-        ExamplesTable table = new ExamplesTable("|nativeFooterToCut|\n|101|");
-        ScreenshotConfiguration screenshotConfiguration = new ExamplesTableToScreenshotConfigurationConverter()
-                .convertValue(table, ScreenshotParameters.class);
-        Assertions.assertAll(() -> assertEquals(Optional.empty(), screenshotConfiguration.getShootingStrategy()),
-                             () -> assertEquals(101, screenshotConfiguration.getCutBottom()),
-                () -> assertEquals(List.of(
-                    warn("Screenshot configuration `nativeFooterToCut` is deprecated, use `cutBottom` instead.")),
-                        LOGGER.getLoggingEvents()));
+        assertAll(
+                () -> assertEquals(Optional.empty(), screenshotConfiguration.getShootingStrategy()),
+                () -> assertEquals(101, screenshotConfiguration.getCutTop())
+        );
     }
 }

--- a/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/screenshot/WebScreenshotConfiguration.java
+++ b/vividus-plugin-web-app/src/main/java/org/vividus/ui/web/screenshot/WebScreenshotConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.vividus.ui.screenshot.ScreenshotConfiguration;
 public class WebScreenshotConfiguration extends ScreenshotConfiguration
 {
     private int nativeHeaderToCut;
+    private int nativeFooterToCut;
     private int webHeaderToCut;
     private int webFooterToCut;
     private Optional<Locator> scrollableElement = Optional.empty();
@@ -41,6 +42,16 @@ public class WebScreenshotConfiguration extends ScreenshotConfiguration
     public void setWebHeaderToCut(int webHeaderToCut)
     {
         this.webHeaderToCut = webHeaderToCut;
+    }
+
+    public int getNativeFooterToCut()
+    {
+        return nativeFooterToCut;
+    }
+
+    public void setNativeFooterToCut(int nativeFooterToCut)
+    {
+        this.nativeFooterToCut = nativeFooterToCut;
     }
 
     public int getWebFooterToCut()


### PR DESCRIPTION
- Deprecated screenshot configuration parameter `nativeFooterToCut` is remove, use `cutBottom` parameter for mobile applications.
- Deprecated property `mobile.screenshot.strategy.<YOUR_STRATEGY_NAME>.native-footer-to-cut` is removed, use `mobile.screenshot.strategy.<YOUR_STRATEGY_NAME>.cut-bottom`