### PR TITLE
[vividus] Remove deprecated internal property for all composite files

### DIFF
--- a/vividus/src/main/resources/properties/deprecated/deprecated.properties
+++ b/vividus/src/main/resources/properties/deprecated/deprecated.properties
@@ -1,2 +1,1 @@
-bdd.configuration.all-composite-paths=engine.composite-paths
 batch-(\\d+)\\.story-execution-timeout=batch-$1.story.execution-timeout


### PR DESCRIPTION
Previously property `bdd.configuration.all-composite-paths` was internal (it's not expected to be used by end-users) and it's used to configure composite files paths: both internal and external. But it's turned out users misused the property and overrode default VIVIDUS composite steps, the decision was taken to drop the property and it was implemented in #3436. The property was deprecated in favour of `engine.composite-paths` to do not break backward compatibility.