### PR TITLE
[plugin-accessibility] Align target field deserialization with axe core rules

### DIFF
--- a/vividus-plugin-accessibility/src/main/java/org/vividus/accessibility/deserializer/TargetDeserializer.java
+++ b/vividus-plugin-accessibility/src/main/java/org/vividus/accessibility/deserializer/TargetDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.accessibility.deserializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.vividus.accessibility.model.axe.Target;
+
+public class TargetDeserializer extends JsonDeserializer<Target>
+{
+    @Override
+    public Target deserialize(JsonParser p, DeserializationContext ctxt) throws IOException
+    {
+        JsonNode root = p.getCodec().readTree(p);
+
+        if (root.isEmpty())
+        {
+            return null;
+        }
+
+        JsonNode firstChild = root.get(0);
+        boolean insideShadowDom = firstChild.isArray();
+        JsonNode elements = insideShadowDom ? firstChild : root;
+
+        List<String> selectors = new ArrayList<>();
+        elements.forEach(node -> selectors.add(node.asText()));
+
+        return new Target(insideShadowDom, selectors);
+    }
+}

--- a/vividus-plugin-accessibility/src/main/java/org/vividus/accessibility/model/axe/Node.java
+++ b/vividus-plugin-accessibility/src/main/java/org/vividus/accessibility/model/axe/Node.java
@@ -18,11 +18,16 @@ package org.vividus.accessibility.model.axe;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.vividus.accessibility.deserializer.TargetDeserializer;
+
 public class Node
 {
     private String impact;
     private String html;
-    private List<String> target;
+    @JsonDeserialize(using = TargetDeserializer.class)
+    private Target target;
     private List<CheckResult> any;
     private List<CheckResult> all;
     private List<CheckResult> none;
@@ -47,12 +52,12 @@ public class Node
         this.html = html;
     }
 
-    public List<String> getTarget()
+    public Target getTarget()
     {
         return target;
     }
 
-    public void setTarget(List<String> target)
+    public void setTarget(Target target)
     {
         this.target = target;
     }

--- a/vividus-plugin-accessibility/src/main/java/org/vividus/accessibility/model/axe/Target.java
+++ b/vividus-plugin-accessibility/src/main/java/org/vividus/accessibility/model/axe/Target.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.accessibility.model.axe;
+
+import java.util.List;
+
+public class Target
+{
+    private final boolean insideShadowDom;
+    private final List<String> selectorsChain;
+
+    public Target(boolean insideShadowDom, List<String> selectorsChain)
+    {
+        this.insideShadowDom = insideShadowDom;
+        this.selectorsChain = selectorsChain;
+    }
+
+    public boolean isInsideShadowDom()
+    {
+        return insideShadowDom;
+    }
+
+    public List<String> getSelectorsChain()
+    {
+        return selectorsChain;
+    }
+}

--- a/vividus-plugin-accessibility/src/main/resources/org/vividus/accessibility/axe-accessibility-report.ftl
+++ b/vividus-plugin-accessibility/src/main/resources/org/vividus/accessibility/axe-accessibility-report.ftl
@@ -252,9 +252,22 @@ Report source: https://lpelypenko.github.io/axe-html-reporter/
                                                                     <td>${node?index}</td>
                                                                     <td>
                                                                         <p><strong>Element location</strong></p>
-                                                                        <#list node.getTarget() as target>
-                                                                            <pre><code class="css text-wrap">${target}</code></pre>
-                                                                        </#list>
+
+                                                                        <#assign insideShadowDom = node.getTarget().isInsideShadowDom() >
+                                                                        <#assign selectors = node.getTarget().getSelectorsChain() >
+
+                                                                        <#if !insideShadowDom && selectors?size == 1>
+                                                                            <pre><code class="css text-wrap">${selectors[0]}</code></pre>
+                                                                        <#else>
+                                                                            <#list selectors as selector>
+                                                                                <#if selector?index != selectors?size - 1>
+                                                                                    <p><i>${insideShadowDom?then('Shadow host', 'Frame')} #${selector?index + 1}:</i></p>
+                                                                                <#else>
+                                                                                    <p><i>Element:</i></p>
+                                                                                </#if>
+                                                                                <pre><code class="css text-wrap">${selector}</code></pre>
+                                                                            </#list>
+                                                                        </#if>
                                                                         <p><strong>Element source</strong></p>
                                                                         <pre><code class="html text-wrap"><#outputformat 'HTML'>${node.getHtml()}</#outputformat></code></pre>
                                                                     </td>

--- a/vividus-plugin-accessibility/src/test/java/org/vividus/accessibility/deserializer/TargetDeserializerTests.java
+++ b/vividus-plugin-accessibility/src/test/java/org/vividus/accessibility/deserializer/TargetDeserializerTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.accessibility.deserializer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.vividus.accessibility.model.axe.Target;
+
+class TargetDeserializerTests
+{
+    private static final List<String> SELECTORS = List.of("selector1", "selector2");
+
+    private final TargetDeserializer deserializer = new TargetDeserializer();
+
+    @Test
+    void shouldDeserializeTarget() throws IOException
+    {
+        String json = """
+                [
+                    "selector1",
+                    "selector2"
+                ]
+                """;
+        Target target = deserializer.deserialize(createParser(json), null);
+        assertNotNull(target);
+        assertFalse(target.isInsideShadowDom());
+        assertEquals(SELECTORS, target.getSelectorsChain());
+    }
+
+    @Test
+    void shouldDeserializeTargetInsideShadowDom() throws IOException
+    {
+        String json = """
+                [
+                    [
+                        "selector1",
+                        "selector2"
+                    ]
+                ]
+                """;
+        Target target = deserializer.deserialize(createParser(json), null);
+        assertNotNull(target);
+        assertTrue(target.isInsideShadowDom());
+        assertEquals(SELECTORS, target.getSelectorsChain());
+    }
+
+    @Test
+    void shouldDeserializeTargetEmpty() throws IOException
+    {
+        Target target = deserializer.deserialize(createParser("[]"), null);
+        assertNull(target);
+    }
+
+    private JsonParser createParser(String json) throws IOException
+    {
+        JsonParser parser = new JsonFactory().createParser(json);
+        parser.setCodec(new ObjectMapper());
+        return parser;
+    }
+}

--- a/vividus-plugin-accessibility/src/test/resources/org/vividus/accessibility/executor/axe-core.json
+++ b/vividus-plugin-accessibility/src/test/resources/org/vividus/accessibility/executor/axe-core.json
@@ -34,5 +34,45 @@
                 ]
             }
         ]
+    },
+    {
+        "type": "passed",
+        "results": [
+            {
+                "id": "aria-required-attr",
+                "impact": null,
+                "tags": [
+                    "cat.aria",
+                    "wcag2a",
+                    "wcag412"
+                ],
+                "description": "Ensures elements with ARIA roles have all required ARIA attributes",
+                "help": "Required ARIA attributes must be provided",
+                "helpUrl": "https://dequeuniversity.com/rules/axe/4.7/aria-required-attr?application=axeAPI",
+                "nodes": [
+                    {
+                        "any": [
+                            {
+                                "id": "aria-required-attr",
+                                "data": null,
+                                "relatedNodes": [],
+                                "impact": "critical",
+                                "message": "All required ARIA attributes are present"
+                            }
+                        ],
+                        "all": [],
+                        "none": [],
+                        "impact": null,
+                        "html": "<div class=\"skip-links \" role=\"region\" aria-label=\"Skip Links\" data-acsb=\"skipLinks\">",
+                        "target": [
+                            [
+                                "access-widget-ui[data-acsb=\"skipLinks\"]",
+                                ".skip-links"
+                            ]
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Accessibility check is broken on listerine.com and tyenol.com sites because target field deserialization doesn't cover all output forms of target field described here: https://www.deque.com/axe/core-documentation/api-documentation/
```
target - Array of either strings or Arrays of strings. If the item in the array is a string, then it is a CSS selector. 
If there are multiple items in the array each item corresponds to one level of iframe or frame. If there is one iframe or frame, there should be two entries in target. 
If there are three iframe levels, there should be four entries in target. 
If the item in the Array is an Array of strings, then it points to an element in a shadow DOM and each item (except the n-1th) in this array is a selector to a DOM element with a shadow DOM. 
The last element in the array points to the final shadow DOM node.
```