### PR TITLE
[CI] Upload code coverage results from all platforms

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -109,14 +109,14 @@ jobs:
         path: vividus/output/reports/tests
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && (!github.event.pull_request.head.repo.fork || github.ref == 'refs/heads/master') }}
+      if: ${{ !github.event.pull_request.head.repo.fork || github.ref == 'refs/heads/master'}}
       uses: codecov/codecov-action@v3.1.4
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && github.event.pull_request.head.repo.fork }}
+      if: ${{ github.event.pull_request.head.repo.fork }}
       uses: codecov/codecov-action@v3.1.4
 
     - name: VIVIDUS tasks validation


### PR DESCRIPTION
There are OS-specific tests, in order to get the full picture of code coverage it's needed to upload results generated at all platforms. Codecov will do reports merging automatically: https://docs.codecov.com/docs/merging-reports