### PR TITLE
[CI] Fix execution of web-tests on Mobitru

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -349,13 +349,17 @@ jobs:
       shell: bash
       run: |
         if [[ -n $MOBITRU_USER && -n $MOBITRU_KEY ]]; then
-          declare -a profiles=( iphone android )
-          for profile in "${profiles[@]}"; do
-            ./gradlew :vividus-tests:debugStories -Pvividus.configuration.suites=health_check \
-                                                  -Pvividus.configuration.profiles=mobitru/web,web/phone/${profile} \
-                                                  -Pvividus.selenium.grid.username=${MOBITRU_USER} \
-                                                  -Pvividus.selenium.grid.password=${MOBITRU_KEY}
-          done
+
+          ./gradlew :vividus-tests:debugStories -Pvividus.configuration.suites=health_check \
+                                                -Pvividus.configuration.profiles=mobitru/web,web/phone/iphone \
+                                                -Pvividus.selenium.grid.capabilities.appium\:platformVersion=16.1 \
+                                                -Pvividus.selenium.grid.username=${MOBITRU_USER} \
+                                                -Pvividus.selenium.grid.password=${MOBITRU_KEY}
+
+          ./gradlew :vividus-tests:debugStories -Pvividus.configuration.suites=health_check \
+                                                -Pvividus.configuration.profiles=mobitru/web,web/phone/android \
+                                                -Pvividus.selenium.grid.username=${MOBITRU_USER} \
+                                                -Pvividus.selenium.grid.password=${MOBITRU_KEY}
         else
             echo No MOBITRU_USER and/or MOBITRU_KEY, Mobitru web mobile system tests will be skipped
         fi


### PR DESCRIPTION
The `platformVersion` is not required; however, Mobitru is currently facing some issues with device allocation. To address this issue, the iOS version is being forced to `16` in the CI.
