### PR TITLE
[plugin-mobitru] Add ability to disable iOS app resigning with Mobitru profile

### DIFF
--- a/docs/modules/plugins/pages/plugin-mobitru.adoc
+++ b/docs/modules/plugins/pages/plugin-mobitru.adoc
@@ -110,6 +110,11 @@ NOTE: The properties marked with *bold* are mandatory.
 |`<empty>`
 |The file name of the application under test uploaded to Mobitru. The application should be uploaded either via https://app.mobitru.com/static/mstfdocs/public/Mobitru_User_Guide.pdf[UI] or https://app.mobitru.com/wiki/api/#api-InstallApp-UpdateArtifact[REST API].
 
+|[subs=+quotes]`*mobitru.app-no-resign*`
+|`true` to avoid resign and `false` if not`.
+|`false`
+|(iOS only) Query parameter to avoid the resign ipa with Mobitru profile or not.
+
 |[subs=+quotes]`*mobile-application.bundle-id*`
 |The valid application package name or bundle id.
 |`<empty>`

--- a/docs/modules/plugins/pages/plugin-mobitru.adoc
+++ b/docs/modules/plugins/pages/plugin-mobitru.adoc
@@ -86,7 +86,7 @@ selenium.grid.capabilities.mobitru-device-search\:manufacturer=SAMSUNG
 
 NOTE: The properties marked with *bold* are mandatory.
 
-[cols="6,2,3,5", options="header"]
+[cols="5,3,3,5", options="header"]
 
 |===
 
@@ -110,15 +110,16 @@ NOTE: The properties marked with *bold* are mandatory.
 |`<empty>`
 |The file name of the application under test uploaded to Mobitru. The application should be uploaded either via https://app.mobitru.com/static/mstfdocs/public/Mobitru_User_Guide.pdf[UI] or https://app.mobitru.com/wiki/api/#api-InstallApp-UpdateArtifact[REST API].
 
-|[subs=+quotes]`*mobitru.app-no-resign*`
-|`true` to avoid resign and `false` if not`.
-|`false`
-|(iOS only) Query parameter to avoid the resign ipa with Mobitru profile or not.
-
 |[subs=+quotes]`*mobile-application.bundle-id*`
 |The valid application package name or bundle id.
 |`<empty>`
 |`Package name` for Android or `Bundle identifier` from `Plist.info` for iOS. It is used to activate the application under tests after Appium session start.
+
+|`mobitru.resign-ios-app`
+a|`true` +
+`false`
+|`true`
+|(iOS only) Resign the application (*.ipa) with Mobitru profile or not.
 
 |`mobitru.device-wait-timeout`
 |The duration in {durations-format-link} format.

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruClient.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruClient.java
@@ -72,9 +72,9 @@ public class MobitruClient
         executeRequest(DEVICE_PATH + "/" + deviceId, HttpMethod.DELETE, UnaryOperator.identity(), HttpStatus.SC_OK);
     }
 
-    public void installApp(String deviceId, String appId, boolean isNoResign) throws MobitruOperationException
+    public void installApp(String deviceId, String appId, boolean resign) throws MobitruOperationException
     {
-        String url = String.format("/storage/install/%s/%s?noResign=%s", deviceId, appId, isNoResign);
+        String url = String.format("/storage/install/%s/%s?noResign=%s", deviceId, appId, !resign);
         executeGet(url, HttpStatus.SC_CREATED);
     }
 

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruClient.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruClient.java
@@ -72,9 +72,10 @@ public class MobitruClient
         executeRequest(DEVICE_PATH + "/" + deviceId, HttpMethod.DELETE, UnaryOperator.identity(), HttpStatus.SC_OK);
     }
 
-    public void installApp(String deviceId, String appId) throws MobitruOperationException
+    public void installApp(String deviceId, String appId, boolean isNoResign) throws MobitruOperationException
     {
-        executeGet(String.format("/storage/install/%s/%s", deviceId, appId), HttpStatus.SC_CREATED);
+        String url = String.format("/storage/install/%s/%s?noResign=%s", deviceId, appId, isNoResign);
+        executeGet(url, HttpStatus.SC_CREATED);
     }
 
     private byte[] executeGet(String relativeUrl, int expectedResponseCode) throws MobitruOperationException

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacade.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacade.java
@@ -36,9 +36,10 @@ public interface MobitruFacade
      *
      * @param deviceId    The UDID of the device
      * @param appRealName The application to install filename.
+     * @param isNoResign The query parameter to avoid the resign ipa with Mobitru profile or not.
      * @throws MobitruOperationException In case of any issues during application installation.
      */
-    void installApp(String deviceId, String appRealName) throws MobitruOperationException;
+    void installApp(String deviceId, String appRealName, boolean isNoResign) throws MobitruOperationException;
 
     /**
      * Returns the device with specified UDID to the devices pool.

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacade.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacade.java
@@ -36,10 +36,10 @@ public interface MobitruFacade
      *
      * @param deviceId    The UDID of the device
      * @param appRealName The application to install filename.
-     * @param isNoResign The query parameter to avoid the resign ipa with Mobitru profile or not.
+     * @param resign      (iOS only) Resign the application (*.ipa) with Mobitru profile or not.
      * @throws MobitruOperationException In case of any issues during application installation.
      */
-    void installApp(String deviceId, String appRealName, boolean isNoResign) throws MobitruOperationException;
+    void installApp(String deviceId, String appRealName, boolean resign) throws MobitruOperationException;
 
     /**
      * Returns the device with specified UDID to the devices pool.

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacadeImpl.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacadeImpl.java
@@ -79,9 +79,9 @@ public class MobitruFacadeImpl implements MobitruFacade
     }
 
     @Override
-    public void installApp(String deviceId, String appRealName) throws MobitruOperationException
+    public void installApp(String deviceId, String appRealName, boolean isNoResign) throws MobitruOperationException
     {
-        mobitruClient.installApp(deviceId, findApp(appRealName));
+        mobitruClient.installApp(deviceId, findApp(appRealName), isNoResign);
     }
 
     @Override

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacadeImpl.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacadeImpl.java
@@ -79,9 +79,9 @@ public class MobitruFacadeImpl implements MobitruFacade
     }
 
     @Override
-    public void installApp(String deviceId, String appRealName, boolean isNoResign) throws MobitruOperationException
+    public void installApp(String deviceId, String appRealName, boolean resign) throws MobitruOperationException
     {
-        mobitruClient.installApp(deviceId, findApp(appRealName), isNoResign);
+        mobitruClient.installApp(deviceId, findApp(appRealName), resign);
     }
 
     @Override

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjuster.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjuster.java
@@ -29,7 +29,7 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
     private final MobitruFacade mobitruFacade;
 
     private String appFileName;
-    private boolean isNoResign;
+    private boolean resignIosApp = true;
 
     public MobitruCapabilitiesAdjuster(MobitruFacade mobitruFacade)
     {
@@ -43,7 +43,7 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
         try
         {
             deviceId = mobitruFacade.takeDevice(desiredCapabilities);
-            mobitruFacade.installApp(deviceId, appFileName, isNoResign);
+            mobitruFacade.installApp(deviceId, appFileName, resignIosApp);
             Map<String, Object> capabilities = desiredCapabilities.asMap();
             if (capabilities.containsKey(APPIUM_UDID) || capabilities.containsKey("udid"))
             {
@@ -73,8 +73,8 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
         this.appFileName = appFileName;
     }
 
-    public void setIsNoResign(boolean noResign)
+    public void setResignIosApp(boolean resignIosApp)
     {
-        this.isNoResign = noResign;
+        this.resignIosApp = resignIosApp;
     }
 }

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjuster.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjuster.java
@@ -29,6 +29,7 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
     private final MobitruFacade mobitruFacade;
 
     private String appFileName;
+    private boolean isNoResign;
 
     public MobitruCapabilitiesAdjuster(MobitruFacade mobitruFacade)
     {
@@ -42,7 +43,7 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
         try
         {
             deviceId = mobitruFacade.takeDevice(desiredCapabilities);
-            mobitruFacade.installApp(deviceId, appFileName);
+            mobitruFacade.installApp(deviceId, appFileName, isNoResign);
             Map<String, Object> capabilities = desiredCapabilities.asMap();
             if (capabilities.containsKey(APPIUM_UDID) || capabilities.containsKey("udid"))
             {
@@ -70,5 +71,10 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
     public void setAppFileName(String appFileName)
     {
         this.appFileName = appFileName;
+    }
+
+    public void setIsNoResign(boolean noResign)
+    {
+        this.isNoResign = noResign;
     }
 }

--- a/vividus-plugin-mobitru/src/main/resources/properties/profile/mobitru/mobile_app/profile.properties
+++ b/vividus-plugin-mobitru/src/main/resources/properties/profile/mobitru/mobile_app/profile.properties
@@ -3,3 +3,4 @@ spring.profiles.active=mobile_app,mobitru
 selenium.grid.capabilities.automationName=${selenium.grid.automation-name}
 
 mobitru.device-wait-timeout=PT5M
+mobitru.resign-ios-app=true

--- a/vividus-plugin-mobitru/src/main/resources/vividus-plugin/spring.xml
+++ b/vividus-plugin-mobitru/src/main/resources/vividus-plugin/spring.xml
@@ -9,6 +9,7 @@
 
     <bean class="org.vividus.mobitru.selenium.MobitruCapabilitiesAdjuster" >
         <property name="appFileName" value="${mobitru.app-file-name}" />
+        <property name="isNoResign" value="${mobitru.app-no-resign:false}" />
     </bean>
 
     <bean class="org.vividus.mobitru.mobileapp.MobitruApplicationActivator" >

--- a/vividus-plugin-mobitru/src/main/resources/vividus-plugin/spring.xml
+++ b/vividus-plugin-mobitru/src/main/resources/vividus-plugin/spring.xml
@@ -9,7 +9,7 @@
 
     <bean class="org.vividus.mobitru.selenium.MobitruCapabilitiesAdjuster" >
         <property name="appFileName" value="${mobitru.app-file-name}" />
-        <property name="isNoResign" value="${mobitru.app-no-resign:false}" />
+        <property name="resignIosApp" value="${mobitru.resign-ios-app}" />
     </bean>
 
     <bean class="org.vividus.mobitru.mobileapp.MobitruApplicationActivator" >

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
@@ -54,6 +54,8 @@ class MobitruClientTests
     private static final String DEVICE_ENDPOINT = "/billing/unit/vividus/automation/api/device/deviceid";
     private static final String DEVICE_ID = "deviceid";
     private static final String TAKE_DEVICE_ENDPOINT = "/billing/unit/vividus/automation/api/device";
+    private static final String EXPECTED_INSTALL_RELATIVE_URL =
+            "/billing/unit/vividus/automation/api/storage/install/udid/fileid?noResign=false";
 
     @Mock private IHttpClient httpClient;
     @Mock private HttpResponse httpResponse;
@@ -179,13 +181,12 @@ class MobitruClientTests
             builderMock.when(HttpRequestBuilder::create).thenReturn(builder);
             when(builder.withEndpoint(ENDPOINT)).thenReturn(builder);
             when(builder.withHttpMethod(HttpMethod.GET)).thenReturn(builder);
-            when(builder.withRelativeUrl("/billing/unit/vividus/automation/api/storage/install/udid/fileid"))
-                    .thenReturn(builder);
+            when(builder.withRelativeUrl(EXPECTED_INSTALL_RELATIVE_URL)).thenReturn(builder);
             when(builder.build()).thenReturn(httpRequest);
             when(httpClient.execute(httpRequest)).thenReturn(httpResponse);
             when(httpResponse.getResponseBody()).thenReturn(RESPONSE);
             when(httpResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
-            mobitruClient.installApp("udid", "fileid");
+            mobitruClient.installApp("udid", "fileid", false);
             verify(httpClient).execute(httpRequest);
         }
     }

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
@@ -54,8 +54,6 @@ class MobitruClientTests
     private static final String DEVICE_ENDPOINT = "/billing/unit/vividus/automation/api/device/deviceid";
     private static final String DEVICE_ID = "deviceid";
     private static final String TAKE_DEVICE_ENDPOINT = "/billing/unit/vividus/automation/api/device";
-    private static final String EXPECTED_INSTALL_RELATIVE_URL =
-            "/billing/unit/vividus/automation/api/storage/install/udid/fileid?noResign=false";
 
     @Mock private IHttpClient httpClient;
     @Mock private HttpResponse httpResponse;
@@ -181,12 +179,14 @@ class MobitruClientTests
             builderMock.when(HttpRequestBuilder::create).thenReturn(builder);
             when(builder.withEndpoint(ENDPOINT)).thenReturn(builder);
             when(builder.withHttpMethod(HttpMethod.GET)).thenReturn(builder);
-            when(builder.withRelativeUrl(EXPECTED_INSTALL_RELATIVE_URL)).thenReturn(builder);
+            when(builder.withRelativeUrl(
+                    "/billing/unit/vividus/automation/api/storage/install/udid/fileid?noResign=false")).thenReturn(
+                    builder);
             when(builder.build()).thenReturn(httpRequest);
             when(httpClient.execute(httpRequest)).thenReturn(httpResponse);
             when(httpResponse.getResponseBody()).thenReturn(RESPONSE);
             when(httpResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
-            mobitruClient.installApp("udid", "fileid", false);
+            mobitruClient.installApp("udid", "fileid", true);
             verify(httpClient).execute(httpRequest);
         }
     }

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
@@ -169,8 +169,12 @@ class MobitruClientTests
         }
     }
 
-    @Test
-    void shouldInstallApp() throws IOException, MobitruOperationException
+    @ParameterizedTest
+    @CsvSource({
+            "true,  noResign=false",
+            "false, noResign=true"
+    })
+    void shouldInstallApp(boolean resign, String urlQuery) throws IOException, MobitruOperationException
     {
         var builder = mock(HttpRequestBuilder.class);
         ClassicHttpRequest httpRequest = mock();
@@ -180,13 +184,13 @@ class MobitruClientTests
             when(builder.withEndpoint(ENDPOINT)).thenReturn(builder);
             when(builder.withHttpMethod(HttpMethod.GET)).thenReturn(builder);
             when(builder.withRelativeUrl(
-                    "/billing/unit/vividus/automation/api/storage/install/udid/fileid?noResign=false")).thenReturn(
+                    "/billing/unit/vividus/automation/api/storage/install/udid/fileid?" + urlQuery)).thenReturn(
                     builder);
             when(builder.build()).thenReturn(httpRequest);
             when(httpClient.execute(httpRequest)).thenReturn(httpResponse);
             when(httpResponse.getResponseBody()).thenReturn(RESPONSE);
             when(httpResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
-            mobitruClient.installApp("udid", "fileid", true);
+            mobitruClient.installApp("udid", "fileid", resign);
             verify(httpClient).execute(httpRequest);
         }
     }

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruFacadeImplTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruFacadeImplTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,6 +69,7 @@ class MobitruFacadeImplTests
     private static final String CAPABILITIES_JSON = CAPABILITIES_JSON_PREFIX
             + "\"platformVersion\":\"12\",\"deviceName\":\"SAMSUNG SM-G998B\",\"udid\":\"Z3CT103D2DZ\"}}";
     private static final Map<String, String> DEVICE_SEARCH_PARAMETERS = Map.of("type", PHONE);
+    private static final boolean DEFAULT_NO_RESIGN_VALUE = false;
 
     private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(MobitruFacadeImpl.class);
 
@@ -180,8 +182,8 @@ class MobitruFacadeImplTests
         when(mobitruClient.getArtifacts()).thenReturn(
                 "[{\"realName\" : \"test.apk\", \"id\" : \"1\"}, {\"realName\" : \"app.apk\", \"id\" : \"2\"}]"
             .getBytes(StandardCharsets.UTF_8));
-        mobitruFacadeImpl.installApp(UDID, "app.apk");
-        verify(mobitruClient).installApp(UDID, "2");
+        mobitruFacadeImpl.installApp(UDID, "app.apk", DEFAULT_NO_RESIGN_VALUE);
+        verify(mobitruClient).installApp(UDID, "2", DEFAULT_NO_RESIGN_VALUE);
     }
 
     @Test
@@ -192,11 +194,11 @@ class MobitruFacadeImplTests
                         + " \"uploadedAt\" : \"33189300000\"}]")
                         .getBytes(StandardCharsets.UTF_8));
         var exception = assertThrows(MobitruOperationException.class,
-            () -> mobitruFacadeImpl.installApp(UDID, "starfield.apk"));
+            () -> mobitruFacadeImpl.installApp(UDID, "starfield.apk", DEFAULT_NO_RESIGN_VALUE));
         assertEquals("Unable to find application with the name `starfield.apk`. The available applications are: "
             + "[Application{id='1', realName='123.apk', uploadedBy='Mithrandir', uploadedAt=33189300000}]",
                 exception.getMessage());
-        verify(mobitruClient, never()).installApp(any(), any());
+        verify(mobitruClient, never()).installApp(any(), any(), anyBoolean());
     }
 
     @Test
@@ -212,9 +214,9 @@ class MobitruFacadeImplTests
     {
         when(mobitruClient.getArtifacts()).thenReturn("[{".getBytes(StandardCharsets.UTF_8));
         var exception = assertThrows(MobitruOperationException.class,
-            () -> mobitruFacadeImpl.installApp(UDID, null));
+            () -> mobitruFacadeImpl.installApp(UDID, null, DEFAULT_NO_RESIGN_VALUE));
         assertInstanceOf(IOException.class, exception.getCause());
-        verify(mobitruClient, never()).installApp(any(), any());
+        verify(mobitruClient, never()).installApp(any(), any(), anyBoolean());
     }
 
     private Device createDevice(String platformVersion, String deviceName, String udid)

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruFacadeImplTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruFacadeImplTests.java
@@ -69,7 +69,7 @@ class MobitruFacadeImplTests
     private static final String CAPABILITIES_JSON = CAPABILITIES_JSON_PREFIX
             + "\"platformVersion\":\"12\",\"deviceName\":\"SAMSUNG SM-G998B\",\"udid\":\"Z3CT103D2DZ\"}}";
     private static final Map<String, String> DEVICE_SEARCH_PARAMETERS = Map.of("type", PHONE);
-    private static final boolean DEFAULT_NO_RESIGN_VALUE = false;
+    private static final boolean DEFAULT_RESIGN_VALUE = true;
 
     private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(MobitruFacadeImpl.class);
 
@@ -182,8 +182,8 @@ class MobitruFacadeImplTests
         when(mobitruClient.getArtifacts()).thenReturn(
                 "[{\"realName\" : \"test.apk\", \"id\" : \"1\"}, {\"realName\" : \"app.apk\", \"id\" : \"2\"}]"
             .getBytes(StandardCharsets.UTF_8));
-        mobitruFacadeImpl.installApp(UDID, "app.apk", DEFAULT_NO_RESIGN_VALUE);
-        verify(mobitruClient).installApp(UDID, "2", DEFAULT_NO_RESIGN_VALUE);
+        mobitruFacadeImpl.installApp(UDID, "app.apk", DEFAULT_RESIGN_VALUE);
+        verify(mobitruClient).installApp(UDID, "2", DEFAULT_RESIGN_VALUE);
     }
 
     @Test
@@ -194,7 +194,7 @@ class MobitruFacadeImplTests
                         + " \"uploadedAt\" : \"33189300000\"}]")
                         .getBytes(StandardCharsets.UTF_8));
         var exception = assertThrows(MobitruOperationException.class,
-            () -> mobitruFacadeImpl.installApp(UDID, "starfield.apk", DEFAULT_NO_RESIGN_VALUE));
+            () -> mobitruFacadeImpl.installApp(UDID, "starfield.apk", DEFAULT_RESIGN_VALUE));
         assertEquals("Unable to find application with the name `starfield.apk`. The available applications are: "
             + "[Application{id='1', realName='123.apk', uploadedBy='Mithrandir', uploadedAt=33189300000}]",
                 exception.getMessage());
@@ -214,7 +214,7 @@ class MobitruFacadeImplTests
     {
         when(mobitruClient.getArtifacts()).thenReturn("[{".getBytes(StandardCharsets.UTF_8));
         var exception = assertThrows(MobitruOperationException.class,
-            () -> mobitruFacadeImpl.installApp(UDID, null, DEFAULT_NO_RESIGN_VALUE));
+            () -> mobitruFacadeImpl.installApp(UDID, null, DEFAULT_RESIGN_VALUE));
         assertInstanceOf(IOException.class, exception.getCause());
         verify(mobitruClient, never()).installApp(any(), any(), anyBoolean());
     }

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjusterTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjusterTests.java
@@ -45,13 +45,29 @@ class MobitruCapabilitiesAdjusterTests
     private static final String UDID = "Z3CV103D2DO";
     private static final String STEAM_APK = "steam.apk";
     private static final String APPIUM_UDID = "appium:udid";
+    private static final boolean DEFAULT_NO_RESIGN_VALUE = false;
+    private static final boolean NO_RESIGN_ENABLED_VALUE = true;
 
     @Mock private MobitruFacade mobitruFacade;
 
     @InjectMocks private MobitruCapabilitiesAdjuster mobitruCapabilitiesConfigurer;
 
     @Test
-    void shouldTakeDeviceInstallAnAppAndSetUdidToTheCapabilities() throws MobitruOperationException
+    void shouldTakeDeviceInstallAnAppIfNoResignIsEnabled() throws MobitruOperationException
+    {
+        mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
+        mobitruCapabilitiesConfigurer.setIsNoResign(NO_RESIGN_ENABLED_VALUE);
+        var capabilities = mock(DesiredCapabilities.class);
+        when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
+        var ordered = Mockito.inOrder(mobitruFacade);
+        assertEquals(Map.of(APPIUM_UDID, UDID), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
+        ordered.verify(mobitruFacade).takeDevice(capabilities);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, NO_RESIGN_ENABLED_VALUE);
+        verify(mobitruFacade, never()).returnDevice(UDID);
+    }
+
+    @Test
+    void shouldTakeDeviceInstallAnAppIfNoResignIsNotSpecified() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
         var capabilities = mock(DesiredCapabilities.class);
@@ -59,7 +75,21 @@ class MobitruCapabilitiesAdjusterTests
         var ordered = Mockito.inOrder(mobitruFacade);
         assertEquals(Map.of(APPIUM_UDID, UDID), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
         ordered.verify(mobitruFacade).takeDevice(capabilities);
-        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
+        verify(mobitruFacade, never()).returnDevice(UDID);
+    }
+
+    @Test
+    void shouldTakeDeviceInstallAnAppAndSetUdidToTheCapabilities() throws MobitruOperationException
+    {
+        mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
+        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
+        var capabilities = mock(DesiredCapabilities.class);
+        when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
+        var ordered = Mockito.inOrder(mobitruFacade);
+        assertEquals(Map.of(APPIUM_UDID, UDID), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
+        ordered.verify(mobitruFacade).takeDevice(capabilities);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
         verify(mobitruFacade, never()).returnDevice(UDID);
     }
 
@@ -69,12 +99,13 @@ class MobitruCapabilitiesAdjusterTests
         throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
+        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
         var capabilities = new DesiredCapabilities(Map.of(udidCapabilityName, UDID));
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
         var ordered = Mockito.inOrder(mobitruFacade);
         assertEquals(Map.of(), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
         ordered.verify(mobitruFacade).takeDevice(capabilities);
-        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
         verify(mobitruFacade, never()).returnDevice(UDID);
     }
 
@@ -82,10 +113,11 @@ class MobitruCapabilitiesAdjusterTests
     void shouldWrapExceptionAndStopDeviceUsage() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
+        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
         var capabilities = new DesiredCapabilities();
         var exception = new MobitruOperationException(UDID);
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
-        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK);
+        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
         var iae = assertThrows(IllegalStateException.class, () -> mobitruCapabilitiesConfigurer.adjust(capabilities));
         verify(mobitruFacade).returnDevice(UDID);
         assertEquals(exception, iae.getCause());
@@ -107,10 +139,11 @@ class MobitruCapabilitiesAdjusterTests
     void shouldRethrowAnExceptionIfItsHappensDuringStoppage() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
+        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
         var capabilities = new DesiredCapabilities();
         var exception = new MobitruOperationException(UDID);
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
-        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK);
+        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
         var secondException = new MobitruOperationException(UDID);
         doThrow(secondException).when(mobitruFacade).returnDevice(UDID);
         var uie = assertThrows(IllegalStateException.class,

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjusterTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjusterTests.java
@@ -45,24 +45,24 @@ class MobitruCapabilitiesAdjusterTests
     private static final String UDID = "Z3CV103D2DO";
     private static final String STEAM_APK = "steam.apk";
     private static final String APPIUM_UDID = "appium:udid";
-    private static final boolean DEFAULT_NO_RESIGN_VALUE = false;
-    private static final boolean NO_RESIGN_ENABLED_VALUE = true;
+    private static final boolean DEFAULT_RESIGN_IOS_APP_VALUE = true;
 
     @Mock private MobitruFacade mobitruFacade;
 
     @InjectMocks private MobitruCapabilitiesAdjuster mobitruCapabilitiesConfigurer;
 
     @Test
-    void shouldTakeDeviceInstallAnAppIfNoResignIsEnabled() throws MobitruOperationException
+    void shouldTakeDeviceInstallAnAppIfResignIsDisabled() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
-        mobitruCapabilitiesConfigurer.setIsNoResign(NO_RESIGN_ENABLED_VALUE);
+        boolean resignIosApp = false;
+        mobitruCapabilitiesConfigurer.setResignIosApp(resignIosApp);
         var capabilities = mock(DesiredCapabilities.class);
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
         var ordered = Mockito.inOrder(mobitruFacade);
         assertEquals(Map.of(APPIUM_UDID, UDID), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
         ordered.verify(mobitruFacade).takeDevice(capabilities);
-        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, NO_RESIGN_ENABLED_VALUE);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, resignIosApp);
         verify(mobitruFacade, never()).returnDevice(UDID);
     }
 
@@ -75,7 +75,7 @@ class MobitruCapabilitiesAdjusterTests
         var ordered = Mockito.inOrder(mobitruFacade);
         assertEquals(Map.of(APPIUM_UDID, UDID), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
         ordered.verify(mobitruFacade).takeDevice(capabilities);
-        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_RESIGN_IOS_APP_VALUE);
         verify(mobitruFacade, never()).returnDevice(UDID);
     }
 
@@ -83,13 +83,13 @@ class MobitruCapabilitiesAdjusterTests
     void shouldTakeDeviceInstallAnAppAndSetUdidToTheCapabilities() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
-        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
+        mobitruCapabilitiesConfigurer.setResignIosApp(DEFAULT_RESIGN_IOS_APP_VALUE);
         var capabilities = mock(DesiredCapabilities.class);
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
         var ordered = Mockito.inOrder(mobitruFacade);
         assertEquals(Map.of(APPIUM_UDID, UDID), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
         ordered.verify(mobitruFacade).takeDevice(capabilities);
-        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_RESIGN_IOS_APP_VALUE);
         verify(mobitruFacade, never()).returnDevice(UDID);
     }
 
@@ -99,13 +99,13 @@ class MobitruCapabilitiesAdjusterTests
         throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
-        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
+        mobitruCapabilitiesConfigurer.setResignIosApp(DEFAULT_RESIGN_IOS_APP_VALUE);
         var capabilities = new DesiredCapabilities(Map.of(udidCapabilityName, UDID));
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
         var ordered = Mockito.inOrder(mobitruFacade);
         assertEquals(Map.of(), mobitruCapabilitiesConfigurer.getExtraCapabilities(capabilities));
         ordered.verify(mobitruFacade).takeDevice(capabilities);
-        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
+        ordered.verify(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_RESIGN_IOS_APP_VALUE);
         verify(mobitruFacade, never()).returnDevice(UDID);
     }
 
@@ -113,11 +113,11 @@ class MobitruCapabilitiesAdjusterTests
     void shouldWrapExceptionAndStopDeviceUsage() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
-        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
+        mobitruCapabilitiesConfigurer.setResignIosApp(DEFAULT_RESIGN_IOS_APP_VALUE);
         var capabilities = new DesiredCapabilities();
         var exception = new MobitruOperationException(UDID);
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
-        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
+        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_RESIGN_IOS_APP_VALUE);
         var iae = assertThrows(IllegalStateException.class, () -> mobitruCapabilitiesConfigurer.adjust(capabilities));
         verify(mobitruFacade).returnDevice(UDID);
         assertEquals(exception, iae.getCause());
@@ -139,11 +139,11 @@ class MobitruCapabilitiesAdjusterTests
     void shouldRethrowAnExceptionIfItsHappensDuringStoppage() throws MobitruOperationException
     {
         mobitruCapabilitiesConfigurer.setAppFileName(STEAM_APK);
-        mobitruCapabilitiesConfigurer.setIsNoResign(DEFAULT_NO_RESIGN_VALUE);
+        mobitruCapabilitiesConfigurer.setResignIosApp(DEFAULT_RESIGN_IOS_APP_VALUE);
         var capabilities = new DesiredCapabilities();
         var exception = new MobitruOperationException(UDID);
         when(mobitruFacade.takeDevice(capabilities)).thenReturn(UDID);
-        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_NO_RESIGN_VALUE);
+        doThrow(exception).when(mobitruFacade).installApp(UDID, STEAM_APK, DEFAULT_RESIGN_IOS_APP_VALUE);
         var secondException = new MobitruOperationException(UDID);
         doThrow(secondException).when(mobitruFacade).returnDevice(UDID);
         var uie = assertThrows(IllegalStateException.class,


### PR DESCRIPTION
Mobitru API for app installation has separate parameter, which is noResign, and it allows to avoid the ipa resign with Mobitru profile.
For now, this parameter is not specifying in the MobitruClient class, which means that resign is always enabled.
It causes critical issues for some people, who want to use the vividus and mobitru.