### PR TITLE
[vividus-engine] Fix logging of deprecated steps without parameters inside composite steps

### DIFF
--- a/vividus-engine/src/main/java/org/vividus/replacement/DeprecatedStepNotificationFactory.java
+++ b/vividus-engine/src/main/java/org/vividus/replacement/DeprecatedStepNotificationFactory.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,8 +46,8 @@ public class DeprecatedStepNotificationFactory
     protected String createDeprecatedStepNotification(String versionToRemove, String replacementFormatPattern)
     {
         String runningDeprecatedStep = runTestContext.getRunningStory().getRunningSteps().getFirst();
-        Matcher stepMatcher = getStepMatcher(runningDeprecatedStep);
-        String[] stepParams = getParametersFromStep(stepMatcher);
+        Optional<Matcher> stepMatcher = getStepMatcher(runningDeprecatedStep);
+        String[] stepParams = stepMatcher.map(this::getParametersFromStep).orElseGet(() -> new String[0]);
 
         String notification;
         try (Formatter newStep = new Formatter())
@@ -59,7 +60,7 @@ public class DeprecatedStepNotificationFactory
         return notification;
     }
 
-    private Matcher getStepMatcher(String rawDeprecatedStep)
+    private Optional<Matcher> getStepMatcher(String rawDeprecatedStep)
     {
         List<Matcher> matchers = new ArrayList<>();
         Keywords keywords = configuration.keywords();
@@ -73,7 +74,7 @@ public class DeprecatedStepNotificationFactory
                 matchers.add(matcher);
             }
         }
-        return matchers.stream().max(Comparator.comparing(Matcher::groupCount)).orElse(null);
+        return matchers.stream().max(Comparator.comparing(Matcher::groupCount));
     }
 
     private String[] getParametersFromStep(Matcher stepMatcher)

--- a/vividus-engine/src/test/java/org/vividus/replacement/DeprecatedStepNotificationFactoryTests.java
+++ b/vividus-engine/src/test/java/org/vividus/replacement/DeprecatedStepNotificationFactoryTests.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import org.jbehave.core.configuration.Configuration;
 import org.jbehave.core.configuration.Keywords;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -42,6 +43,9 @@ import org.vividus.model.RunningStory;
 @ExtendWith(MockitoExtension.class)
 class DeprecatedStepNotificationFactoryTests
 {
+    private static final String DEPRECATION_MSG_FORMAT =
+            "The step: \"%s\" is deprecated and will be removed in VIVIDUS %s. Use step: \"%s\"";
+
     private static final String REMOVE_VERSION = "0.7.0";
 
     private static final String NOT_PARAMETERIZED_STEP_VALUE = "step without parameters deprecated";
@@ -93,11 +97,24 @@ class DeprecatedStepNotificationFactoryTests
         when(collectingStepPatternsMonitor.getRegisteredStepPatterns()).thenReturn(stepPatternsCache);
 
         mockRunTestContext(deprecatedStep);
-        String expectedNotification = String.format(
-                "The step: \"%s\" is deprecated and will be removed in VIVIDUS %s. Use step: \"%s\"", deprecatedStep,
-                REMOVE_VERSION, expectedActualStep);
+        String expectedNotification = String.format(DEPRECATION_MSG_FORMAT, deprecatedStep, REMOVE_VERSION,
+                expectedActualStep);
         assertEquals(expectedNotification, deprecatedStepNotificationFactory
                 .createDeprecatedStepNotification(REMOVE_VERSION, formatPattern));
+    }
+
+    @Test
+    void shouldGetNotificationForRunningDeprecatedStepWithoutPattern()
+    {
+        Map<String, Pattern> stepPatternsCache = new ConcurrentHashMap<>();
+        when(configuration.keywords()).thenReturn(new Keywords());
+        when(collectingStepPatternsMonitor.getRegisteredStepPatterns()).thenReturn(stepPatternsCache);
+
+        mockRunTestContext(NOT_PARAMETERIZED_STEP_DEPR);
+        String expectedNotification = String.format(DEPRECATION_MSG_FORMAT, NOT_PARAMETERIZED_STEP_DEPR, REMOVE_VERSION,
+                NOT_PARAMETERIZED_STEP_ACTUAL);
+        assertEquals(expectedNotification, deprecatedStepNotificationFactory
+                .createDeprecatedStepNotification(REMOVE_VERSION, NOT_PARAMETERIZED_STEP_ACTUAL));
     }
 
     private void mockRunTestContext(String deprecatedStep)


### PR DESCRIPTION
Closes #4680