### PR TITLE
[plugin-websocket] Bump Jetty websocket client from 11 to 12

### DIFF
--- a/vividus-plugin-websocket/build.gradle
+++ b/vividus-plugin-websocket/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     implementation platform(group: 'org.springframework', name: 'spring-framework-bom', version: '6.1.3')
     implementation(group: 'org.springframework', name: 'spring-websocket')
-    implementation(group: 'org.eclipse.jetty.websocket', name: 'websocket-jakarta-client', version: '11.0.19')
+    implementation(group: 'org.eclipse.jetty.ee10.websocket', name: 'jetty-ee10-websocket-jakarta-client', version: '12.0.5')
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.10.1')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')


### PR DESCRIPTION
Also fixes error:
```
(java.lang.NoSuchMethodError: 'jakarta.websocket.ClientEndpointConfig$Builder jakarta.websocket.ClientEndpointConfig$Builder.sslContext(javax.net.ssl.SSLContext)') 2024-01-12 16:06:56,606 [batch-1-thread-1] ERROR org.vividus.log.LoggingStoryReporter - Step is failed with exception
 org.jbehave.core.failures.UUIDExceptionWrapper: When I connect to `echo` websocket
	at org.jbehave.core.steps.StepCreator$ParametrisedStep.perform(StepCreator.java:914) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.steps.StepCreator$ReportingAbstractStep.perform(StepCreator.java:639) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$FineSoFar.run(PerformableTree.java:379) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableSteps.perform(PerformableTree.java:1442) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.lambda$performScenario$0(PerformableTree.java:1284) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableEntity.performWithStopExecutionExceptionHandling(PerformableTree.java:966) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$AbstractPerformableScenario.performScenario(PerformableTree.java:1277) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$NormalPerformableScenario.perform(PerformableTree.java:1333) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableScenario.perform(PerformableTree.java:1226) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableStory.lambda$perform$0(PerformableTree.java:1091) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableEntity.performWithStopExecutionExceptionHandling(PerformableTree.java:966) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree$PerformableStory.perform(PerformableTree.java:1083) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree.performCancellable(PerformableTree.java:521) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.PerformableTree.perform(PerformableTree.java:488) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.StoryManager$EnqueuedStory.call(StoryManager.java:305) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at org.jbehave.core.embedder.StoryManager$EnqueuedStory.call(StoryManager.java:278) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: java.lang.NoSuchMethodError: 'jakarta.websocket.ClientEndpointConfig$Builder jakarta.websocket.ClientEndpointConfig$Builder.sslContext(javax.net.ssl.SSLContext)'
	at org.springframework.web.socket.client.standard.StandardWebSocketClient.executeInternal(StandardWebSocketClient.java:167) ~[spring-websocket-6.1.3.jar:6.1.3]
	at org.springframework.web.socket.client.AbstractWebSocketClient.execute(AbstractWebSocketClient.java:95) ~[spring-websocket-6.1.3.jar:6.1.3]
	at org.springframework.web.socket.client.AbstractWebSocketClient.execute(AbstractWebSocketClient.java:67) ~[spring-websocket-6.1.3.jar:6.1.3]
	at org.vividus.steps.websocket.WebSocketSteps.connect(WebSocketSteps.java:91) ~[vividus-plugin-websocket-0.6.6-SNAPSHOT.jar:0.6.6-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at org.jbehave.core.steps.StepCreator$ParametrisedStep.perform(StepCreator.java:895) ~[jbehave-core-6.0.0-alpha.3.jar:?]
	... 19 more
```