### PR TITLE
[plugin-web-app] Revert invalid fix of scroll script

### DIFF
--- a/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-element-into-viewport-center.js
+++ b/vividus-plugin-web-app/src/main/resources/org/vividus/ui/web/action/scroll-element-into-viewport-center.js
@@ -28,7 +28,7 @@ try {
         currentWindow.addEventListener("scrollend", scrollEndEventListener);
     }
 
-    currentWindow.scrollBy(0, elementToScroll.getBoundingClientRect().top - currentWindow.scrollY - currentWindow.innerHeight * stickyHeaderSize);
+    currentWindow.scrollBy(0, elementToScroll.getBoundingClientRect().top - currentWindow.innerHeight * stickyHeaderSize);
 }
 catch(e) {
     // swallow error quietly

--- a/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/action/WebJavascriptActionsTests.java
+++ b/vividus-plugin-web-app/src/test/java/org/vividus/ui/web/action/WebJavascriptActionsTests.java
@@ -109,7 +109,7 @@ class WebJavascriptActionsTests
     void testScrollElementIntoViewportCenter()
     {
         var webElement = mock(WebElement.class);
-        var stickyHeaderSize = 111_122;
+        var stickyHeaderSize = 25;
         javascriptActions.setStickyHeaderSizePercentage(stickyHeaderSize);
         javascriptActions.scrollElementIntoViewportCenter(webElement);
         verify((JavascriptExecutor) webDriver).executeAsyncScript(

--- a/vividus-tests/src/main/resources/properties/environment/integration/environment.properties
+++ b/vividus-tests/src/main/resources/properties/environment/integration/environment.properties
@@ -1,4 +1,6 @@
 web-application.main-page-url=${variables.vividus-test-site-url}
+web-application.sticky-header-size-percentage=50
+
 rest-api.http.endpoint=https://httpbingo.org/
 variables.http-endpoint=${rest-api.http.endpoint}
 


### PR DESCRIPTION
This partially reverts 213f1c65b4. The root cause of the issue was a wrong size of sticky header: it was more than 50% of window height.