### PR TITLE
[vividus] Do not fail when total table rows number is less than random rows transformer parameter

### DIFF
--- a/docs/modules/commons/pages/table-transformers.adoc
+++ b/docs/modules/commons/pages/table-transformers.adoc
@@ -261,22 +261,25 @@ will result in the following xref:ROOT:glossary.adoc#_examplestable[ExamplesTabl
 |Description
 
 |`byMaxColumns`
-|the maximum number of columns to keep
+|The maximum number of columns to keep. If the number of columns in the original table is less than the value specified
+in this parameter, then all the original table columns are kept.
 
 |`byMaxRows`
-|the maximum number of rows to keep
+|The maximum number of rows to keep. If the number of rows in the original table is less than the value specified in
+this parameter, then all the original table rows are kept.
 
 |`byRandomRows`
-|the number of random rows to keep
+|The number of random rows to keep. If the number of rows in the original table is less than the value specified in this
+parameter, then all the original table rows are kept.
 
 |`byColumnNames`
-|the names of the columns to keep separated by semicolon
+|The names of the columns to keep separated by semicolon.
 
 |`byRowIndexes`
-|the zero-based indexes of the rows to keep, allowing individual indexes and ranges of indexes separated by semicolons. The range of indexes is specified using the hyphen (-) symbol between two indexes (e.g., 0-5).
+|The zero-based indexes of the rows to keep, allowing individual indexes and ranges of indexes separated by semicolons. The range of indexes is specified using the hyphen (-) symbol between two indexes (e.g., 0-5).
 
 |`column.<column name>=<regex>`
-a|select rows where the value in the specified column matches the given regex.
+a|Select rows where the value in the specified column matches the given regex.
 
 IMPORTANT: filtering by regex is not allowed to be used alongside with the following properties: `byMaxColumns`, `byColumnNames`, `byMaxRows`, `byRowIndexes`, `byRandomRows`.
 

--- a/vividus/src/main/java/org/vividus/transformer/FilteringTableTransformer.java
+++ b/vividus/src/main/java/org/vividus/transformer/FilteringTableTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,9 +116,10 @@ public class FilteringTableTransformer extends AbstractFilteringTableTransformer
         else if (byRandomRows != null)
         {
             int randomRowsCount = Integer.parseInt(byRandomRows);
-            isTrue(randomRowsCount <= numberOfRows,
-                    "'byRandomRows' is %d, but it must be less than or equal to %d (the number of table rows)",
-                    randomRowsCount, numberOfRows);
+            if (randomRowsCount >= numberOfRows)
+            {
+                return rows;
+            }
             return ThreadLocalRandom.current()
                     .ints(0, numberOfRows)
                     .distinct()


### PR DESCRIPTION
If the number of rows in the original table is less than the value specified in 'byRandomRows' parameter, then all the original table rows are kept.