### PR TITLE
[CI] Disable video player integration tests in MacOS

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -125,8 +125,26 @@ jobs:
          ./gradlew validateKnownIssues printSteps countSteps -x testVividusInitialization  -p vividus-tests --project-prop 'vividus.variables.iterationLimit=3' --project-prop 'vividus.variables.target-platform=ios'
 
     - name: Integration tests
+      if: (matrix.platform == 'ubuntu-latest' || matrix.platform == 'windows-latest')
       run: |
         ./gradlew :vividus-tests:debugStories --project-prop 'vividus.configuration-set.active=integration' --project-prop 'vividus.allure.history-directory=output/history/integration-tests' --project-prop 'vividus.allure.executor.name="Github Actions (Vividus)"' --project-prop 'vividus.allure.executor.type=github' --project-prop 'vividus.allure.executor.url=https://github.com/vividus-framework/vividus/actions' --project-prop 'vividus.allure.executor.build-order=${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.build-name="Integration Tests ${GITHUB_RUN_ID}"' --project-prop 'vividus.allure.executor.build-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.report-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID}' --project-prop 'vividus.allure.executor.report-name="Integration tests report"' --project-prop "fileToSaveExitCode=$(pwd)/exitCode.txt" --no-daemon
+
+    - name: Integration tests
+      if: matrix.platform == 'macos-latest'
+      run: |
+        ./gradlew :vividus-tests:debugStories -Pvividus.configuration-set.active=integration \
+                                              -Pvividus.batch-1.resource-exclude-patterns="Precondition*.story,Load ExamplesTable from local file.story,VideoSteps.story" \
+                                              -Pvividus.allure.history-directory=output/history/integration-tests \
+                                              -Pvividus.allure.executor.name="Github Actions (Vividus)" \
+                                              -Pvividus.allure.executor.type=github \
+                                              -Pvividus.allure.executor.url=https://github.com/vividus-framework/vividus/actions \
+                                              -Pvividus.allure.executor.build-order=${GITHUB_RUN_ID} \
+                                              -Pvividus.allure.executor.build-name="Integration Tests ${GITHUB_RUN_ID}" \
+                                              -Pvividus.allure.executor.build-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID} \
+                                              -Pvividus.allure.executor.report-url=https://github.com/vividus-framework/vividus/actions/runs/${GITHUB_RUN_ID} \
+                                              -Pvividus.allure.executor.report-name="Integration tests report" \
+                                              -PfileToSaveExitCode=$(pwd)/exitCode.txt --no-daemon
+
 
     - name: Publish integration tests report
       if: always()


### PR DESCRIPTION
There is a connectivity issue from GitHub MacOS runner, the video does not start in 20 seconds:
![image](https://github.com/vividus-framework/vividus/assets/5081226/aa6665d6-ff2c-4dbb-808f-14ccd83542ad)
