### PR TITLE
[plugin-lighthouse] Remove PWA category

### DIFF
--- a/docs/modules/plugins/pages/plugin-lighthouse.adoc
+++ b/docs/modules/plugins/pages/plugin-lighthouse.adoc
@@ -25,8 +25,8 @@ include::partial$plugin-installation.adoc[]
 |The API key that identifies your project and provides you with API access, quota, and reports. Its recommended to specify the key if you plan to use the plugin in an automated way and make multiple queries per second.
 
 |`lighthouse.categories`
-|comma-separated list of categories (`performance`, `pwa`, `best-practices`, `accessibility`, `seo`)
-|`performance,pwa,best-practices,accessibility,seo`
+|comma-separated list of categories (`performance`, `best-practices`, `accessibility`, `seo`)
+|`performance,best-practices,accessibility,seo`
 |The audit categories to run, by default the scan includes all 5 categories, but you can select particular ones depending on which aspects of your website you wish to analyze.
 
 |`lighthouse.performance.percentile`
@@ -70,7 +70,6 @@ include::partial$lighthouse-scan-type.adoc[]
 **** `Accessibility Score`
 **** `Best Practices Score`
 **** `Performance Score`
-**** `PWA Score`
 **** `SEO Score`
 ** `$rule` - xref:parameters:comparison-rule.adoc[The comparison rule].
 ** `$threshold` - The expected integer or floating (e.g. `0.35`) number.
@@ -88,7 +87,6 @@ When I perform Lighthouse full scan of `https://dequeuniversity.com/demo/mars` p
 |Accessibility Score     |GREATER_THAN|90       |
 |Best Practices Score    |EQUAL_TO    |100      |
 |Performance Score       |GREATER_THAN|95       |
-|PWA Score               |GREATER_THAN|20       |
 |SEO Score               |GREATER_THAN|85       |
 ----
 

--- a/vividus-plugin-lighthouse/src/main/java/org/vividus/lighthouse/LighthouseSteps.java
+++ b/vividus-plugin-lighthouse/src/main/java/org/vividus/lighthouse/LighthouseSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,11 +62,10 @@ public final class LighthouseSteps
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(LighthouseSteps.class);
 
-    private static final Map<String, Function<Categories, LighthouseCategoryV5>> CUSTOM_METRIC_FATORIES = Map.of(
+    private static final Map<String, Function<Categories, LighthouseCategoryV5>> CUSTOM_METRIC_FACTORIES = Map.of(
         "accessibilityScore", Categories::getAccessibility,
         "bestPracticesScore", Categories::getBestPractices,
         "performanceScore", Categories::getPerformance,
-        "pwaScore", Categories::getPwa,
         "seoScore", Categories::getSeo
     );
 
@@ -276,7 +275,7 @@ public final class LighthouseSteps
         }
 
         Categories scanCategories = result.getCategories();
-        CUSTOM_METRIC_FATORIES.forEach((m, f) ->
+        CUSTOM_METRIC_FACTORIES.forEach((m, f) ->
         {
             LighthouseCategoryV5 categoryValue = f.apply(scanCategories);
             if (categoryValue != null)

--- a/vividus-plugin-lighthouse/src/main/resources/properties/defaults/default.properties
+++ b/vividus-plugin-lighthouse/src/main/resources/properties/defaults/default.properties
@@ -1,4 +1,4 @@
 lighthouse.application-name=
 lighthouse.api-key=
-lighthouse.categories=performance,pwa,best-practices,accessibility,seo
+lighthouse.categories=performance,best-practices,accessibility,seo
 lighthouse.acceptable-score-percentage-delta=5

--- a/vividus-plugin-lighthouse/src/test/java/org/vividus/lighthouse/LighthouseStepsTests.java
+++ b/vividus-plugin-lighthouse/src/test/java/org/vividus/lighthouse/LighthouseStepsTests.java
@@ -109,8 +109,7 @@ class LighthouseStepsTests
     private static final BigDecimal SCORE_METRIC_VAL = new BigDecimal(0.99f);
     private static final String RESULT_AS_STRING = "{}";
     private static final String SEO = "seo";
-    private static final List<String> CATEGORIES = List.of("performance", "pwa", "best-practices", "accessibility",
-            SEO);
+    private static final List<String> CATEGORIES = List.of("performance", "best-practices", "accessibility", SEO);
     private static final String DESKTOP_STRATEGY = ScanType.DESKTOP.getStrategies()[0];
     private static final String UNKNOWN_ERROR_MESSAGE = "Lighthouse returned error: Something went wrong.";
     private static final String PERFORMANCE_SCORE_LOG = "The performance score of the measurement #{} is {}";

--- a/vividus-tests/src/main/resources/story/integration/LighthouseSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/LighthouseSteps.story
@@ -12,7 +12,6 @@ When I perform Lighthouse desktop scan of `${vividus-test-site-url}` page:
 |Accessibility Score     |GREATER_THAN|85       |
 |Best Practices Score    |GREATER_THAN|90       |
 |Performance Score       |GREATER_THAN|90       |
-|PWA Score               |GREATER_THAN|20       |
 |SEO Score               |GREATER_THAN|85       |
 
 


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/releases/tag/v12.0.0: 
"As per [Chrome’s updated Installability Criteria](https://developer.chrome.com/blog/update-install-criteria), Lighthouse [has removed the PWA category](https://github.com/GoogleChrome/lighthouse/pull/15455). For future PWA testing, users will be directed to use the [updated PWA documentation](https://developer.chrome.com/docs/devtools/progressive-web-apps/)."