### PR TITLE
[plugin-web-app-to-rest-api] Quietly handle non-encoded Sitemap URLs by `FROM_SITEMAP` transformer

### DIFF
--- a/vividus-plugin-web-app-to-rest-api/src/main/java/org/vividus/crawler/transformer/AbstractFetchingUrlsTableTransformer.java
+++ b/vividus-plugin-web-app-to-rest-api/src/main/java/org/vividus/crawler/transformer/AbstractFetchingUrlsTableTransformer.java
@@ -57,13 +57,15 @@ public abstract class AbstractFetchingUrlsTableTransformer implements ExtendedTa
     {
         checkTableEmptiness(tableAsString);
         Set<String> urls = fetchUrls(properties).stream()
-                .map(URI::create)
+                .map(this::parseUri)
                 .map(URI::getRawPath)
                 .collect(Collectors.toSet());
         return build(urls, properties);
     }
 
     protected abstract Set<String> fetchUrls(TableProperties properties);
+
+    protected abstract URI parseUri(String uri);
 
     protected Set<String> filterResults(Stream<String> urls)
     {
@@ -112,9 +114,9 @@ public abstract class AbstractFetchingUrlsTableTransformer implements ExtendedTa
     {
         try
         {
-            return httpRedirectsProvider.getRedirects(URI.create(urlAsString)).stream()
-                                                                              .map(URI::toString)
-                                                                              .toList();
+            return httpRedirectsProvider.getRedirects(parseUri(urlAsString)).stream()
+                    .map(URI::toString)
+                    .toList();
         }
         catch (IOException e)
         {

--- a/vividus-plugin-web-app-to-rest-api/src/main/java/org/vividus/crawler/transformer/HeadlessCrawlerTableTransformer.java
+++ b/vividus-plugin-web-app-to-rest-api/src/main/java/org/vividus/crawler/transformer/HeadlessCrawlerTableTransformer.java
@@ -111,6 +111,12 @@ public class HeadlessCrawlerTableTransformer extends AbstractFetchingUrlsTableTr
         return crawledUrlsCache.getUnchecked(mainApplicationPage);
     }
 
+    @Override
+    protected URI parseUri(String uri)
+    {
+        return URI.create(uri);
+    }
+
     public void setCrawlControllerFactory(ICrawlControllerFactory crawlControllerFactory)
     {
         this.crawlControllerFactory = crawlControllerFactory;

--- a/vividus-plugin-web-app-to-rest-api/src/main/java/org/vividus/crawler/transformer/SiteMapTableTransformer.java
+++ b/vividus-plugin-web-app-to-rest-api/src/main/java/org/vividus/crawler/transformer/SiteMapTableTransformer.java
@@ -29,6 +29,7 @@ import org.jbehave.core.model.ExamplesTable.TableProperties;
 import org.vividus.crawler.ISiteMapParser;
 import org.vividus.crawler.SiteMap;
 import org.vividus.crawler.SiteMapParseException;
+import org.vividus.util.UriUtils;
 
 import crawlercommons.sitemaps.SiteMapURL;
 
@@ -83,6 +84,12 @@ public class SiteMapTableTransformer extends AbstractFetchingUrlsTableTransforme
             throw new SiteMapTableGenerationException("No URLs found in sitemap, or all URLs were filtered");
         }
         return urls;
+    }
+
+    @Override
+    protected URI parseUri(String uri)
+    {
+        return UriUtils.createUri(uri);
     }
 
     public void setSiteMapParser(ISiteMapParser siteMapParser)

--- a/vividus-plugin-web-app-to-rest-api/src/test/java/org/vividus/crawler/transformer/FetchingUrlsTableTransformerTests.java
+++ b/vividus-plugin-web-app-to-rest-api/src/test/java/org/vividus/crawler/transformer/FetchingUrlsTableTransformerTests.java
@@ -127,5 +127,11 @@ class FetchingUrlsTableTransformerTests
         {
             return new HashSet<>(List.of("http://someurl/first", "http://someurl.com/second", "/third", "/fourth%25"));
         }
+
+        @Override
+        protected URI parseUri(String uri)
+        {
+            return URI.create(uri);
+        }
     }
 }


### PR DESCRIPTION
According to standard all Sitemap URLs must be URL-escaped and encoded (https://www.sitemaps.org/protocol.html#escaping), but there could be cases when production contains invalid URLs and it's needed to crawl websites, so FROM_SITEMAP transformer must be able to handle such invalid URLs.