### PR TITLE
add support of mobitru doInjection parameter

### DIFF
--- a/docs/modules/plugins/pages/plugin-mobitru.adoc
+++ b/docs/modules/plugins/pages/plugin-mobitru.adoc
@@ -125,7 +125,7 @@ a|`true` +
 a|`true` +
 `false`
 |`false`
-|inject special code into application to allow emulation of "touch id" action and QR code scan.
+|Inject special code into application to allow emulation of "touch id" action and QR code scan.
 
 |`mobitru.device-wait-timeout`
 |The duration in {durations-format-link} format.

--- a/docs/modules/plugins/pages/plugin-mobitru.adoc
+++ b/docs/modules/plugins/pages/plugin-mobitru.adoc
@@ -121,6 +121,12 @@ a|`true` +
 |`true`
 |(iOS only) Resign the application (*.ipa) with Mobitru profile or not.
 
+|`mobitru.do-injection`
+a|`true` +
+`false`
+|`false`
+|inject special code into application to allow emulation of "touch id" action and QR code scan.
+
 |`mobitru.device-wait-timeout`
 |The duration in {durations-format-link} format.
 |`PT5M`

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruClient.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,9 +72,11 @@ public class MobitruClient
         executeRequest(DEVICE_PATH + "/" + deviceId, HttpMethod.DELETE, UnaryOperator.identity(), HttpStatus.SC_OK);
     }
 
-    public void installApp(String deviceId, String appId, boolean resign) throws MobitruOperationException
+    public void installApp(String deviceId, String appId, boolean resign, boolean injection)
+            throws MobitruOperationException
     {
-        String url = String.format("/storage/install/%s/%s?noResign=%s", deviceId, appId, !resign);
+        String url = String.format("/storage/install/%s/%s?noResign=%s&doInjection=%s",
+                deviceId, appId, !resign, injection);
         executeGet(url, HttpStatus.SC_CREATED);
     }
 

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacade.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,9 +37,11 @@ public interface MobitruFacade
      * @param deviceId    The UDID of the device
      * @param appRealName The application to install filename.
      * @param resign      (iOS only) Resign the application (*.ipa) with Mobitru profile or not.
+     * @param injection   inject special code into application to allow emulation of "touch id" action and QR code scan
      * @throws MobitruOperationException In case of any issues during application installation.
      */
-    void installApp(String deviceId, String appRealName, boolean resign) throws MobitruOperationException;
+    void installApp(String deviceId, String appRealName, boolean resign, boolean injection)
+            throws MobitruOperationException;
 
     /**
      * Returns the device with specified UDID to the devices pool.

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacadeImpl.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/client/MobitruFacadeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,9 +79,10 @@ public class MobitruFacadeImpl implements MobitruFacade
     }
 
     @Override
-    public void installApp(String deviceId, String appRealName, boolean resign) throws MobitruOperationException
+    public void installApp(String deviceId, String appRealName, boolean resign, boolean injection)
+            throws MobitruOperationException
     {
-        mobitruClient.installApp(deviceId, findApp(appRealName), resign);
+        mobitruClient.installApp(deviceId, findApp(appRealName), resign, injection);
     }
 
     @Override

--- a/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjuster.java
+++ b/vividus-plugin-mobitru/src/main/java/org/vividus/mobitru/selenium/MobitruCapabilitiesAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
 
     private String appFileName;
     private boolean resignIosApp = true;
+    private boolean doInjection;
 
     public MobitruCapabilitiesAdjuster(MobitruFacade mobitruFacade)
     {
@@ -43,7 +44,7 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
         try
         {
             deviceId = mobitruFacade.takeDevice(desiredCapabilities);
-            mobitruFacade.installApp(deviceId, appFileName, resignIosApp);
+            mobitruFacade.installApp(deviceId, appFileName, resignIosApp, doInjection);
             Map<String, Object> capabilities = desiredCapabilities.asMap();
             if (capabilities.containsKey(APPIUM_UDID) || capabilities.containsKey("udid"))
             {
@@ -76,5 +77,10 @@ public class MobitruCapabilitiesAdjuster extends DesiredCapabilitiesAdjuster
     public void setResignIosApp(boolean resignIosApp)
     {
         this.resignIosApp = resignIosApp;
+    }
+
+    public void setDoInjection(boolean doInjection)
+    {
+        this.doInjection = doInjection;
     }
 }

--- a/vividus-plugin-mobitru/src/main/resources/properties/profile/mobitru/mobile_app/profile.properties
+++ b/vividus-plugin-mobitru/src/main/resources/properties/profile/mobitru/mobile_app/profile.properties
@@ -4,3 +4,4 @@ selenium.grid.capabilities.automationName=${selenium.grid.automation-name}
 
 mobitru.device-wait-timeout=PT5M
 mobitru.resign-ios-app=true
+mobitru.do-injection=false

--- a/vividus-plugin-mobitru/src/main/resources/vividus-plugin/spring.xml
+++ b/vividus-plugin-mobitru/src/main/resources/vividus-plugin/spring.xml
@@ -10,6 +10,7 @@
     <bean class="org.vividus.mobitru.selenium.MobitruCapabilitiesAdjuster" >
         <property name="appFileName" value="${mobitru.app-file-name}" />
         <property name="resignIosApp" value="${mobitru.resign-ios-app}" />
+        <property name="doInjection" value="${mobitru.do-injection}" />
     </bean>
 
     <bean class="org.vividus.mobitru.mobileapp.MobitruApplicationActivator" >

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,10 +171,13 @@ class MobitruClientTests
 
     @ParameterizedTest
     @CsvSource({
-            "true,  noResign=false",
-            "false, noResign=true"
+            "true, true, noResign=false&doInjection=true",
+            "true, false, noResign=false&doInjection=false",
+            "false, true, noResign=true&doInjection=true",
+            "false, false, noResign=true&doInjection=false"
     })
-    void shouldInstallApp(boolean resign, String urlQuery) throws IOException, MobitruOperationException
+    void shouldInstallApp(boolean resign, boolean injection, String urlQuery)
+            throws IOException, MobitruOperationException
     {
         var builder = mock(HttpRequestBuilder.class);
         ClassicHttpRequest httpRequest = mock();
@@ -190,7 +193,7 @@ class MobitruClientTests
             when(httpClient.execute(httpRequest)).thenReturn(httpResponse);
             when(httpResponse.getResponseBody()).thenReturn(RESPONSE);
             when(httpResponse.getStatusCode()).thenReturn(HttpStatus.SC_CREATED);
-            mobitruClient.installApp("udid", "fileid", resign);
+            mobitruClient.installApp("udid", "fileid", resign, injection);
             verify(httpClient).execute(httpRequest);
         }
     }

--- a/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruFacadeImplTests.java
+++ b/vividus-plugin-mobitru/src/test/java/org/vividus/mobitru/client/MobitruFacadeImplTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,7 @@ class MobitruFacadeImplTests
             + "\"platformVersion\":\"12\",\"deviceName\":\"SAMSUNG SM-G998B\",\"udid\":\"Z3CT103D2DZ\"}}";
     private static final Map<String, String> DEVICE_SEARCH_PARAMETERS = Map.of("type", PHONE);
     private static final boolean DEFAULT_RESIGN_VALUE = true;
+    private static final boolean DEFAULT_INJECTION_VALUE = false;
 
     private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(MobitruFacadeImpl.class);
 
@@ -182,8 +183,8 @@ class MobitruFacadeImplTests
         when(mobitruClient.getArtifacts()).thenReturn(
                 "[{\"realName\" : \"test.apk\", \"id\" : \"1\"}, {\"realName\" : \"app.apk\", \"id\" : \"2\"}]"
             .getBytes(StandardCharsets.UTF_8));
-        mobitruFacadeImpl.installApp(UDID, "app.apk", DEFAULT_RESIGN_VALUE);
-        verify(mobitruClient).installApp(UDID, "2", DEFAULT_RESIGN_VALUE);
+        mobitruFacadeImpl.installApp(UDID, "app.apk", DEFAULT_RESIGN_VALUE, DEFAULT_INJECTION_VALUE);
+        verify(mobitruClient).installApp(UDID, "2", DEFAULT_RESIGN_VALUE, DEFAULT_INJECTION_VALUE);
     }
 
     @Test
@@ -194,11 +195,11 @@ class MobitruFacadeImplTests
                         + " \"uploadedAt\" : \"33189300000\"}]")
                         .getBytes(StandardCharsets.UTF_8));
         var exception = assertThrows(MobitruOperationException.class,
-            () -> mobitruFacadeImpl.installApp(UDID, "starfield.apk", DEFAULT_RESIGN_VALUE));
+            () -> mobitruFacadeImpl.installApp(UDID, "starfield.apk", DEFAULT_RESIGN_VALUE, DEFAULT_INJECTION_VALUE));
         assertEquals("Unable to find application with the name `starfield.apk`. The available applications are: "
             + "[Application{id='1', realName='123.apk', uploadedBy='Mithrandir', uploadedAt=33189300000}]",
                 exception.getMessage());
-        verify(mobitruClient, never()).installApp(any(), any(), anyBoolean());
+        verify(mobitruClient, never()).installApp(any(), any(), anyBoolean(), anyBoolean());
     }
 
     @Test
@@ -214,9 +215,9 @@ class MobitruFacadeImplTests
     {
         when(mobitruClient.getArtifacts()).thenReturn("[{".getBytes(StandardCharsets.UTF_8));
         var exception = assertThrows(MobitruOperationException.class,
-            () -> mobitruFacadeImpl.installApp(UDID, null, DEFAULT_RESIGN_VALUE));
+            () -> mobitruFacadeImpl.installApp(UDID, null, DEFAULT_RESIGN_VALUE, DEFAULT_INJECTION_VALUE));
         assertInstanceOf(IOException.class, exception.getCause());
-        verify(mobitruClient, never()).installApp(any(), any(), anyBoolean());
+        verify(mobitruClient, never()).installApp(any(), any(), anyBoolean(), anyBoolean());
     }
 
     private Device createDevice(String platformVersion, String deviceName, String udid)


### PR DESCRIPTION
Add support of doInjection parameter for installing native applications in the Mobitru.
This query parameter enables the injection of special code into an application to allow emulation of "touch id" action and QR code scan.


