### PR TITLE
[CI] Do not run Qodana checks on PRs from forks

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   qodana:
+    if: ${{ !github.event.pull_request.head.repo.fork || github.ref == 'refs/heads/master'}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Starting from version 2023.2 release versions of Qodana Linters require connection to Qodana Cloud. To continue using Qodana, it's required to have an access token and provide the token as the QODANA_TOKEN environment variable. But GitHub prevents PRs from forks from accessing secrets by default. Thus it's needed to disable Qodana workflow for PRs from forks.