### PR TITLE
[plugin-rest-api] Fix generation of report attachments with resources validation results

### DIFF
--- a/vividus-plugin-rest-api/src/main/resources/org/vividus/http/steps/attachment/resources-response-body-fragment.ftl
+++ b/vividus-plugin-rest-api/src/main/resources/org/vividus/http/steps/attachment/resources-response-body-fragment.ftl
@@ -27,7 +27,7 @@ Show HTTP response
 <script type="text/javascript">
     (function() {
             let code = document.querySelector('#pretty-code');
-            <#include "templates/html-formatter-fragment.ftl">
+            <#include "/templates/html-formatter-fragment.ftl">
         hljs.highlightElement(code);
     })();
 </script>


### PR DESCRIPTION
<img width="1050" alt="image" src="https://github.com/user-attachments/assets/1dfde9c8-9dbc-4f17-b7e8-0e2426e50399">
