### PR TITLE
[plugin-web-app-to-rest-api] Migrate back to original Crawler4J

### DIFF
--- a/vividus-plugin-web-app-to-rest-api/build.gradle
+++ b/vividus-plugin-web-app-to-rest-api/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation platform(group: 'org.slf4j', name: 'slf4j-bom', version: '2.0.16')
     implementation(group: 'org.slf4j', name: 'slf4j-api')
     implementation(group: 'com.github.crawler-commons', name: 'crawler-commons', version: '1.4')
-    implementation(group: 'de.hs-heilbronn.mi', name: 'crawler4j-with-hsqldb', version: '5.1.0') { {
+    implementation(group: 'de.hs-heilbronn.mi', name: 'crawler4j-with-hsqldb', version: '5.1.0') {
         exclude module: 'log4j-slf4j-impl'
     }
 

--- a/vividus-plugin-web-app-to-rest-api/build.gradle
+++ b/vividus-plugin-web-app-to-rest-api/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation platform(group: 'org.slf4j', name: 'slf4j-bom', version: '2.0.16')
     implementation(group: 'org.slf4j', name: 'slf4j-api')
     implementation(group: 'com.github.crawler-commons', name: 'crawler-commons', version: '1.4')
-    implementation(group: 'com.github.valfirst.crawler4j', name: 'crawler4j-with-hsqldb', version: '5.0.3') {
+    implementation(group: 'de.hs-heilbronn.mi', name: 'crawler4j-with-hsqldb', version: '5.1.0') { {
         exclude module: 'log4j-slf4j-impl'
     }
 


### PR DESCRIPTION
It seems Crawler4J is not archived anymore: https://github.com/HHN/crawler4j/commit/9b4e2cfbda206b6f976243655aa19610c90aeaf1