### PR TITLE
[CI] Use JDK 23 as runtime

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,11 +68,11 @@ jobs:
         restore-keys: |
           tests-history-cache-
 
-    - name: Set up JDK 21
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 21
+        java-version: 23
 
     - name: Warm up VIVIDUS test site
       run: curl https://vividus-test-site-a92k.onrender.com/ &


### PR DESCRIPTION
Some builds fail with the following errors:
- https://github.com/vividus-framework/vividus/actions/runs/11611021881/job/32336096362
- https://github.com/vividus-framework/vividus/actions/runs/11611021881/job/32337973732

The details can be found here: https://github.com/SeleniumHQ/selenium/issues/11798

The root cause is: https://bugs.openjdk.org/browse/JDK-8304701, which is fixed in JDK 22.