### PR TITLE
[plugin-email] Migrate to Jakarat Mail 2.1

### DIFF
--- a/vividus-plugin-email/build.gradle
+++ b/vividus-plugin-email/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.14.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.icegreen', name: 'greenmail', version: '2.1.0')
-    testImplementation(group: 'com.sun.mail', name: 'smtp', version: mailVersion)
+    testImplementation(group: 'org.eclipse.angus', name: 'smtp', version: '2.0.3')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')
 }

--- a/vividus-plugin-email/build.gradle
+++ b/vividus-plugin-email/build.gradle
@@ -6,18 +6,13 @@ configurations {
     testImplementation.extendsFrom compileOnly
 }
 
-ext {
-    mailVersion = '2.0.1'
-}
-
 dependencies {
     api project(':vividus-engine')
     implementation project(':vividus-util')
     implementation project(':vividus-soft-assert')
 
-    implementation(group: 'jakarta.mail', name: 'jakarta.mail-api', version: mailVersion)
-    implementation(group: 'com.sun.mail', name: 'jakarta.mail', version: mailVersion)
-    implementation(group: 'com.sun.mail', name: 'imap', version: mailVersion)
+    implementation(group: 'jakarta.mail', name: 'jakarta.mail-api', version: '2.1.3')
+    implementation(group: 'org.eclipse.angus', name: 'imap', version: '2.0.3')
 
     implementation(group: 'jakarta.inject', name: 'jakarta.inject-api', version: '2.0.1')
     implementation(group: 'org.apache.commons', name: 'commons-lang3', version: '3.17.0')


### PR DESCRIPTION
https://jakartaee.github.io/mail-api/
August 18, 2021 - Jakarta Mail implementation moves to Eclipse Angus To break tight integration between Jakarta Mail Specification API and the implementation, sources of the implementation were moved to the new project - Eclipse Angus - and further development continues there. Eclipse Angus is the direct successor of JavaMail/JakartaMail.