### PR TITLE
[docs] Remove information about `automationName` capability

### DIFF
--- a/docs/modules/plugins/pages/plugin-mobile-app.adoc
+++ b/docs/modules/plugins/pages/plugin-mobile-app.adoc
@@ -101,23 +101,6 @@ a|`Android`
 |Depends on the set profile
 |Defines the mobile OS to use
 
-|`selenium.grid.automation-name`
-a|`UIAutomator2`
-`XCUITest`
-|Depends on the set profile
-a|Defines automation engine to use
-[cols="1,2", options="header"]
-!===
-
-!Platform
-!Recommended engine
-
-!`Android`
-!https://github.com/appium/appium-uiautomator2-driver#readme[UIAutomator2]
-
-!`iOS`
-!https://appium.github.io/appium-xcuitest-driver/[XCUITest]
-!===
 
 |`mobile-environment.real-device`
 a|`true`


### PR DESCRIPTION
`automationName` capability is a technical one and it's already configured in the corresponding VIVIDUS profiles. Also there is only one engine per platform, no alternative engines are available. So the information is removed to simplify configuration from user side.