### PR TITLE
[plugin-web-app-playwright] Fix invalid element viewport visibility logic

### DIFF
--- a/vividus-plugin-web-app-playwright/src/main/resources/org/vividus/ui/web/playwright/action/check-element-in-viewport.js
+++ b/vividus-plugin-web-app-playwright/src/main/resources/org/vividus/ui/web/playwright/action/check-element-in-viewport.js
@@ -1,5 +1,6 @@
 (element) => {
-    var elementYCoordinate = element.getBoundingClientRect().y;
-    var windowScrollY = Math.floor(window.scrollY);
-    return windowScrollY <= elementYCoordinate && elementYCoordinate <= (windowScrollY + window.innerHeight);
+    const rect = element.getBoundingClientRect();
+    const windowHeight = window.innerHeight;
+
+    return (rect.top >= 0 && rect.top <= windowHeight) || (rect.bottom > 0 && rect.bottom <= windowHeight);
 }


### PR DESCRIPTION
before:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/bf5d121b-9a69-41f1-99c6-0596d7a4bd3d">
after
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/db0d1e11-503c-4eab-b5e6-d05686a8fc0a">
