### PR TITLE
[http-client] Ignore case-sensitivity while matching header names

### DIFF
--- a/vividus-http-client/src/main/java/org/vividus/http/client/HttpResponse.java
+++ b/vividus-http-client/src/main/java/org/vividus/http/client/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class HttpResponse
 
     public Stream<Header> getHeadersByName(String headerName)
     {
-        return Stream.of(responseHeaders).filter(header -> header.getName().equals(headerName));
+        return Stream.of(responseHeaders).filter(header -> header.getName().equalsIgnoreCase(headerName));
     }
 
     public String getMethod()

--- a/vividus-http-client/src/test/java/org/vividus/http/client/HttpResponseTests.java
+++ b/vividus-http-client/src/test/java/org/vividus/http/client/HttpResponseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ class HttpResponseTests
         Header[] headers = { header };
         httpResponse.setResponseHeaders(headers);
         assertEquals(Optional.of(header), httpResponse.getHeaderByName(HEADER_NAME));
+        assertEquals(Optional.of(header), httpResponse.getHeaderByName("NaMe"));
     }
 
     @Test


### PR DESCRIPTION
Spec:
- HTTP1.X - headers are case insensitive
- HTTP2.X - headers are in lower case