### PR TITLE
[CI] Do not run system SauceLabs tests on PRs from forks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -701,7 +701,7 @@ jobs:
 
 
   system-mobile-tests-on-saucelabs:
-    if: ${{ github.repository == 'vividus-framework/vividus' }}
+    if: github.event.pull_request.head.repo.fork == false
     env:
       TEST_APP_VERSION: 0.6.0
     runs-on: ubuntu-latest


### PR DESCRIPTION
Secrets are not accessible in PRs created from forks.

See more why secrets can't be used in conditions: https://github.com/actions/runner/issues/520#issuecomment-1690859769