### PR TITLE
Stop relying on deprecated automatic test framework implementation dependencies

### DIFF
--- a/vividus-agent-reportportal/build.gradle
+++ b/vividus-agent-reportportal/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-allure-adaptor/build.gradle
+++ b/vividus-allure-adaptor/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '2.3.0')

--- a/vividus-analytics/build.gradle
+++ b/vividus-analytics/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-engine/build.gradle
+++ b/vividus-engine/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-exporter-commons/build.gradle
+++ b/vividus-exporter-commons/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     testImplementation (group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: "${springBootVersion}")
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-extension-aws/build.gradle
+++ b/vividus-extension-aws/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-extension-azure/build.gradle
+++ b/vividus-extension-azure/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-extension-selenium/build.gradle
+++ b/vividus-extension-selenium/build.gradle
@@ -46,6 +46,7 @@ configurations {
 
      testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
      testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
      testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
      testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
      testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-extension-ui/build.gradle
+++ b/vividus-extension-ui/build.gradle
@@ -11,6 +11,7 @@ project.description = 'VIVIDUS extension for plugins testing application with gr
 
      testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
      testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
      testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
      testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
      testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-extension-visual-testing/build.gradle
+++ b/vividus-extension-visual-testing/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-extension-web-app/build.gradle
+++ b/vividus-extension-web-app/build.gradle
@@ -13,6 +13,7 @@ project.description = 'VIVIDUS extension for web application testing plugins'
 
      testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
      testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
      testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
      testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
      testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-facade-jira/build.gradle
+++ b/vividus-facade-jira/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-http-client/build.gradle
+++ b/vividus-http-client/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-accessibility/build.gradle
+++ b/vividus-plugin-accessibility/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-applitools/build.gradle
+++ b/vividus-plugin-applitools/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-avro/build.gradle
+++ b/vividus-plugin-avro/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-aws-dynamodb/build.gradle
+++ b/vividus-plugin-aws-dynamodb/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-aws-kinesis/build.gradle
+++ b/vividus-plugin-aws-kinesis/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-aws-lambda/build.gradle
+++ b/vividus-plugin-aws-lambda/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-aws-s3/build.gradle
+++ b/vividus-plugin-aws-s3/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-azure-cosmos-db/build.gradle
+++ b/vividus-plugin-azure-cosmos-db/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version: '3.19.1')

--- a/vividus-plugin-azure-data-factory/build.gradle
+++ b/vividus-plugin-azure-data-factory/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-azure-event-grid/build.gradle
+++ b/vividus-plugin-azure-event-grid/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-azure-event-hub/build.gradle
+++ b/vividus-plugin-azure-event-hub/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-azure-functions/build.gradle
+++ b/vividus-plugin-azure-functions/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-azure-resource-manager/build.gradle
+++ b/vividus-plugin-azure-resource-manager/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '2.3.0')

--- a/vividus-plugin-azure-service-bus/build.gradle
+++ b/vividus-plugin-azure-service-bus/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-azure-storage-account/build.gradle
+++ b/vividus-plugin-azure-storage-account/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-azure-storage-queue/build.gradle
+++ b/vividus-plugin-azure-storage-queue/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-browserstack/build.gradle
+++ b/vividus-plugin-browserstack/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-csv/build.gradle
+++ b/vividus-plugin-csv/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-datetime/build.gradle
+++ b/vividus-plugin-datetime/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-db/build.gradle
+++ b/vividus-plugin-db/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-electron/build.gradle
+++ b/vividus-plugin-electron/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-email/build.gradle
+++ b/vividus-plugin-email/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.icegreen', name: 'greenmail', version: '2.1.3')

--- a/vividus-plugin-excel/build.gradle
+++ b/vividus-plugin-excel/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-html/build.gradle
+++ b/vividus-plugin-html/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     testImplementation project(':vividus-util')
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-json/build.gradle
+++ b/vividus-plugin-json/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-kafka/build.gradle
+++ b/vividus-plugin-kafka/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.springframework.kafka', name: 'spring-kafka-test')

--- a/vividus-plugin-lambdatest/build.gradle
+++ b/vividus-plugin-lambdatest/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-lighthouse/build.gradle
+++ b/vividus-plugin-lighthouse/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-mobile-app/build.gradle
+++ b/vividus-plugin-mobile-app/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-mobitru/build.gradle
+++ b/vividus-plugin-mobitru/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-mongodb/build.gradle
+++ b/vividus-plugin-mongodb/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-parquet/build.gradle
+++ b/vividus-plugin-parquet/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation(group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: "${hadoopVersion}")
 }

--- a/vividus-plugin-rest-api/build.gradle
+++ b/vividus-plugin-rest-api/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-saucelabs/build.gradle
+++ b/vividus-plugin-saucelabs/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-shell/build.gradle
+++ b/vividus-plugin-shell/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '2.3.0')

--- a/vividus-plugin-ssh/build.gradle
+++ b/vividus-plugin-ssh/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-visual/build.gradle
+++ b/vividus-plugin-visual/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-web-app-playwright/build.gradle
+++ b/vividus-plugin-web-app-playwright/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-web-app-to-rest-api/build.gradle
+++ b/vividus-plugin-web-app-to-rest-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-plugin-web-app/build.gradle
+++ b/vividus-plugin-web-app/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')

--- a/vividus-plugin-websocket/build.gradle
+++ b/vividus-plugin-websocket/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-winrm/build.gradle
+++ b/vividus-plugin-winrm/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-xml/build.gradle
+++ b/vividus-plugin-xml/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-plugin-yaml/build.gradle
+++ b/vividus-plugin-yaml/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
 }

--- a/vividus-reporter/build.gradle
+++ b/vividus-reporter/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-soft-assert/build.gradle
+++ b/vividus-soft-assert/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-test-context/build.gradle
+++ b/vividus-test-context/build.gradle
@@ -3,6 +3,7 @@ project.description = 'VIVIDUS test context'
 dependencies {
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-core')
 }

--- a/vividus-to-azure-devops-exporter/build.gradle
+++ b/vividus-to-azure-devops-exporter/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-to-xray-exporter/build.gradle
+++ b/vividus-to-xray-exporter/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-to-zephyr-exporter/build.gradle
+++ b/vividus-to-zephyr-exporter/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test')
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'com.github.valfirst', name: 'slf4j-test', version: '3.0.1')

--- a/vividus-util/build.gradle
+++ b/vividus-util/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testRuntimeOnly(group: 'org.junit.vintage', name: 'junit-vintage-engine')
     testCompileOnly(group: 'junit', name: 'junit', version: '4.13.2')
     testImplementation(group: 'org.hamcrest', name: 'hamcrest', version: '3.0')

--- a/vividus/build.gradle
+++ b/vividus/build.gradle
@@ -101,6 +101,7 @@ dependencies {
 
     testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation platform(group: 'org.mockito', name: 'mockito-bom', version: '5.15.2')
     testImplementation(group: 'org.mockito', name: 'mockito-junit-jupiter')
     testImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '2.3.0')
@@ -125,10 +126,12 @@ dependencies {
     integrationTestImplementation project(':vividus-plugin-yaml')
     integrationTestImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     integrationTestImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    integrationTestRuntimeOnly('org.junit.platform:junit-platform-launcher')
     integrationTestImplementation(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '2.3.0')
 
     systemTestImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.11.4')
     systemTestImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter')
+    systemTestRuntimeOnly('org.junit.platform:junit-platform-launcher')
     systemTestImplementation platform(group: 'org.testcontainers', name: 'testcontainers-bom', version: '1.20.5')
     systemTestImplementation(group: 'org.testcontainers', name: 'testcontainers')
     systemTestImplementation(group: 'org.testcontainers', name: 'junit-jupiter')


### PR DESCRIPTION
https://docs.gradle.org/8.13/userguide/upgrading_version_8.html#test_framework_implementation_dependencies