### PR TITLE
[CI] Set platform name for SauceLabs desktop tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -278,14 +278,26 @@ jobs:
       shell: bash
       run: |
         if [[ -n $SAUCELABS_USER && -n $SAUCELABS_KEY ]]; then
-          declare -a profiles=( iexplore chrome firefox edge safari )
+          declare -a profiles=( chrome firefox edge )
           for profile in "${profiles[@]}"; do
             ./gradlew :vividus-tests:debugStories -Pvividus.configuration.environments=system/saucelabs \
                                                   -Pvividus.configuration.suites=health_check \
                                                   -Pvividus.configuration.profiles=saucelabs/web,web/desktop/${profile} \
                                                   -Pvividus.selenium.grid.username=${SAUCELABS_USER} \
-                                                  -Pvividus.selenium.grid.password=${SAUCELABS_KEY}
+                                                  -Pvividus.selenium.grid.password=${SAUCELABS_KEY} \
+                                                  -Pvividus.selenium.grid.capabilities.platformName="Windows 11"
           done
+          ./gradlew :vividus-tests:debugStories -Pvividus.configuration.environments=system/saucelabs \
+                                                -Pvividus.configuration.suites=health_check \
+                                                -Pvividus.configuration.profiles=saucelabs/web,web/desktop/iexplore \
+                                                -Pvividus.selenium.grid.username=${SAUCELABS_USER} \
+                                                -Pvividus.selenium.grid.password=${SAUCELABS_KEY}
+
+          ./gradlew :vividus-tests:debugStories -Pvividus.configuration.environments=system/saucelabs \
+                                                -Pvividus.configuration.suites=health_check \
+                                                -Pvividus.configuration.profiles=saucelabs/web,web/desktop/safari \
+                                                -Pvividus.selenium.grid.username=${SAUCELABS_USER} \
+                                                -Pvividus.selenium.grid.password=${SAUCELABS_KEY}
         else
             echo No SAUCELABS_USER and/or SAUCELABS_KEY, SauceLabs system tests will be skipped
         fi
@@ -329,7 +341,8 @@ jobs:
                                                 -Pvividus.batch-1.resource-location=story/integration \
                                                 -Pvividus.batch-1.resource-include-patterns=ProxyStepsTests.story \
                                                 -Pvividus.selenium.grid.username=${SAUCELABS_USER} \
-                                                -Pvividus.selenium.grid.password=${SAUCELABS_KEY} \
+                                                -Pvividus.selenium.grid.password=${SAUCELABS_KEY}  \
+                                                -Pvividus.selenium.grid.capabilities.platformName="Windows 11" \
                                                 -Pvividus.saucelabs.sauce-connect.command-line-arguments="--proxy-localhost --no-ssl-bump-domains example.com,vividus-test-site-a92k.onrender.com"
         else
             echo No SAUCELABS_USER and/or SAUCELABS_KEY, SauceLabs system tests will be skipped


### PR DESCRIPTION
Empty `selenium.grid.capabilities.platformName` property results in `"platformName" : "ANY"` capability. SauceLabs has changed the logic, previously ANY platform resulted in Windows, but now it can be MacOS, which in its turn may result in screen resolution conflicts:
```
(org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 404. Message: Misconfigured -- Resolution you specified is not available for this OS/browser/version/device combo: OS: 'Mac 12', Browser: 'googlechrome', Version: '134.0.6998.45', Device: 'unspecified', Screen Resolution: '1920x1080'; available resolutions: '1024x768', '1152x864', '1280x960', '1376x1032', '1440x900', '1600x1200', '1920x1440', '2048x1536'
```