### PR TITLE
[plugin-visual] Save baseline during comparison when there is no original baseline

### DIFF
--- a/vividus-plugin-visual/src/main/java/org/vividus/visual/engine/VisualTestingEngine.java
+++ b/vividus-plugin-visual/src/main/java/org/vividus/visual/engine/VisualTestingEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,14 +107,14 @@ public class VisualTestingEngine implements IVisualTestingEngine
                       (double) (diff.getDiffSize() * ONE_HUNDRED) / (width * height)).setScale(SCALE,
                           RoundingMode.CEILING))
                   .log("The {} visual difference percentage is {}%{} actual was {}%");
-            if (overrideBaselines)
-            {
-                getBaselineStorage(visualCheck).saveBaseline(checkpoint, visualCheck.getBaselineName());
-            }
         }
         else
         {
             comparisonResult.setPassed(false);
+        }
+        if (overrideBaselines)
+        {
+            getBaselineStorage(visualCheck).saveBaseline(checkpoint, visualCheck.getBaselineName());
         }
 
         return comparisonResult;

--- a/vividus-plugin-visual/src/test/java/org/vividus/visual/engine/VisualTestingEngineTests.java
+++ b/vividus-plugin-visual/src/test/java/org/vividus/visual/engine/VisualTestingEngineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -252,6 +252,26 @@ class VisualTestingEngineTests
                 () -> assertTrue(checkResult.isPassed()));
         verify(baselineStorage).saveBaseline(argThat(s -> finalImage.equals(s.getImage())), eq(BASELINE));
         assertThat(testLogger.getLoggingEvents(), is(List.of(buildExpectedLoggingEvent(true, ACCEPTABLE, 0.0, 0))));
+    }
+
+    @Test
+    void shouldOverrideBaselineDuringComparisonActionIfBaselineIsMissed() throws IOException
+    {
+        initObjectUnderTest();
+        visualTestingEngine.setOverrideBaselines(true);
+        when(baselineStorage.getBaseline(BASELINE)).thenReturn(Optional.empty());
+        VisualCheck visualCheck = createVisualCheck(VisualActionType.COMPARE_AGAINST);
+        var finalImage = mockGetCheckpointScreenshot(visualCheck);
+        VisualCheckResult checkResult = visualTestingEngine.compareAgainst(visualCheck);
+        Assertions.assertAll(
+                () -> assertNull(checkResult.getBaseline()),
+                () -> assertEquals(BASELINE, checkResult.getBaselineName()),
+                () -> assertEquals(CHECKPOINT_BASE64, toBase64(checkResult.getCheckpoint())),
+                () -> assertEquals(VisualActionType.COMPARE_AGAINST, checkResult.getActionType()),
+                () -> assertNull(checkResult.getDiff()),
+                () -> assertFalse(checkResult.isPassed()));
+        verify(baselineStorage).saveBaseline(argThat(s -> finalImage.equals(s.getImage())), eq(BASELINE));
+        assertThat(testLogger.getLoggingEvents(), is(empty()));
     }
 
     @Test


### PR DESCRIPTION
Documentation:
**ui.visual.override-baselines** - Used for overriding existing ones or creating not existing baselines during compare action

Fix for "creating not existing baselines during compare action"