### PR TITLE
[tests] Improve stability of health check

### DIFF
--- a/vividus-tests/src/main/resources/story/system/HealthCheck.story
+++ b/vividus-tests/src/main/resources/story/system/HealthCheck.story
@@ -1,6 +1,6 @@
 Meta:
     @layout desktop tablet phone
 
-Scenario: Healthcheck
+Scenario: Health check
 Given I am on page with URL `${vividus-test-site-url}`
-Then number of elements found by `name(vividus-logo)` is = `1`
+When I wait until element located by `name(vividus-logo)` appears


### PR DESCRIPTION
There are cases when page navigation attempt happens before Appium is fully ready (Appium issue?). So navigation is performed, the actual page is not yet opened, but the test checks presence of the element. The wait step is used to avoid such cases and to make tests more stable.