### PR TITLE
[tests] Update device for BrowserStack Android native tests

### DIFF
--- a/vividus-tests/src/main/resources/properties/profile/browserstack/mobile_app/android/profile.properties
+++ b/vividus-tests/src/main/resources/properties/profile/browserstack/mobile_app/android/profile.properties
@@ -1,1 +1,1 @@
-selenium.grid.device-name=Google Pixel 4
+selenium.grid.device-name=Google Pixel 9

--- a/vividus-tests/src/main/resources/properties/profile/browserstack/mobile_app/android/profile.properties
+++ b/vividus-tests/src/main/resources/properties/profile/browserstack/mobile_app/android/profile.properties
@@ -1,1 +1,1 @@
-selenium.grid.device-name=Google Pixel 9
+selenium.grid.device-name=Google Pixel 6


### PR DESCRIPTION
Google Pixel 4 is deprecated:

> org.openqa.selenium.WebDriverException: [BROWSERSTACK_DEPRECATED_DEVICE_ERROR] The device google pixel 4-10.0 has been deprecated from 18 July 2025 onwards. Going forward any tests on device google pixel 4-10.0 will not be supported on BrowserStack. We strongly recommend you update your test scripts. For the current list of supported devices on BrowserStack, please check here - https://www.browserstack.com/list-of-browsers-and-platforms/app_automate