### PR TITLE
[CI] Use Java 24 to run tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -461,11 +461,11 @@ jobs:
         kafka-version: "3.9.0"
         kafka-topics: "vividus-topic,1"
 
-    - name: Set up JDK 23
+    - name: Set up JDK 24
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: 23
+        java-version: 24
 
     - name: System Kafka tests
       shell: bash
@@ -540,11 +540,11 @@ jobs:
           restore-keys: |
             mobile-tests-on-saucelabs-history-cache-
 
-      - name: Set up JDK 23
+      - name: Set up JDK 24
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 23
+          java-version: 24
 
       - name: SauceLabs - Tablet - Web - System tests
         env:
@@ -752,11 +752,11 @@ jobs:
           restore-keys: |
             tests-on-browserstack-history-cache-
 
-      - name: Set up JDK 23
+      - name: Set up JDK 24
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 23
+          java-version: 24
 
       - name: BrowserStack - Mobile - Web - System tests
         env:
@@ -905,11 +905,11 @@ jobs:
           restore-keys: |
             mobile-tests-on-mobitru-history-cache-
 
-      - name: Set up JDK 23
+      - name: Set up JDK 24
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 23
+          java-version: 24
 
       - name: Mobitru - Android - Mobile - Web - System tests
         env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded CI build and test environments to Java 24 across all workflows for consistency and future compatibility.
  * Standardized setup step naming to reflect the new Java version.
  * Benefit: leverages latest performance, security, and tooling improvements in the build pipeline.
  * No changes to product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->