### PR TITLE
[CI] Use Java 25 as runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,11 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: 21
+        java-version: 25
 
     - name: Run static code analysis
       run: ./gradlew spotlessDocumentationCheck

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,11 +65,11 @@ jobs:
         restore-keys: |
           tests-history-cache-
 
-    - name: Set up JDK 24
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: 24
+        java-version: 25
 
     - name: Warm up VIVIDUS test site
       run: curl https://vividus-test-site-a92k.onrender.com/ &
@@ -464,11 +464,11 @@ jobs:
         kafka-version: "3.9.0"
         kafka-topics: "vividus-topic,1"
 
-    - name: Set up JDK 24
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: 24
+        java-version: 25
 
     - name: System Kafka tests
       shell: bash
@@ -543,11 +543,11 @@ jobs:
           restore-keys: |
             mobile-tests-on-saucelabs-history-cache-
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 24
+          java-version: 25
 
       - name: SauceLabs - Tablet - Web - System tests
         env:
@@ -755,11 +755,11 @@ jobs:
           restore-keys: |
             tests-on-browserstack-history-cache-
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 24
+          java-version: 25
 
       - name: BrowserStack - Mobile - Web - System tests
         env:
@@ -908,11 +908,11 @@ jobs:
           restore-keys: |
             mobile-tests-on-mobitru-history-cache-
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 24
+          java-version: 25
 
       - name: Mobitru - Android - Mobile - Web - System tests
         env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the continuous integration and documentation build environments to use JDK 25, aligning all workflows on a consistent Java version.
  * This change helps maintain compatibility with newer Java tooling and keeps the build pipeline current without altering behavior.
  * No user-facing functionality is affected; application features and outputs remain unchanged.
  * Expect the same workflows and results, with improved maintainability of the build and documentation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->