### PR TITLE
Set jsonpath scope to api to avoid compilation problem with JsonPathUtils

### DIFF
--- a/vividus-plugin-azure-resource-manager/build.gradle
+++ b/vividus-plugin-azure-resource-manager/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     implementation project(':vividus-reporter')
     implementation project(':vividus-util')
     implementation('com.azure.resourcemanager:azure-resourcemanager-resources:2.53.3')
-    implementation("com.github.vividus-framework.JsonPath:json-path:${versions.jsonPath}")
 
     testImplementation platform('org.junit:junit-bom:5.13.4')
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/vividus-plugin-json/build.gradle
+++ b/vividus-plugin-json/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     implementation project(':vividus-soft-assert')
     implementation project(':vividus-util')
     api('net.javacrumbs.json-unit:json-unit:4.1.1')
-    implementation("com.github.vividus-framework.JsonPath:json-path:${versions.jsonPath}")
     implementation("com.github.vividus-framework.JsonPath:json-path-assert:${versions.jsonPath}")
     implementation('com.flipkart.zjsonpatch:zjsonpatch:0.4.16')
     implementation platform('io.qameta.allure:allure-bom:2.30.0')

--- a/vividus-plugin-rest-api/build.gradle
+++ b/vividus-plugin-rest-api/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation platform('org.springframework:spring-framework-bom:6.2.11')
     implementation('org.springframework:spring-web')
     implementation('org.apache.commons:commons-lang3:3.19.0')
-    implementation("com.github.vividus-framework.JsonPath:json-path:${versions.jsonPath}")
     implementation("com.github.vividus-framework.JsonPath:json-path-assert:${versions.jsonPath}")
     implementation('org.hamcrest:hamcrest:3.0')
     implementation('org.apache.tika:tika-core:3.2.3')

--- a/vividus-to-xray-exporter/build.gradle
+++ b/vividus-to-xray-exporter/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation('org.zeroturnaround:zt-zip:1.17')
 
     implementation('net.javacrumbs.json-unit:json-unit:4.1.1')
-    implementation('com.jayway.jsonpath:json-path')
 
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation platform('org.junit:junit-bom:5.13.4')

--- a/vividus-to-zephyr-exporter/build.gradle
+++ b/vividus-to-zephyr-exporter/build.gradle
@@ -34,8 +34,6 @@ dependencies {
     implementation('com.google.guava:guava:33.5.0-jre')
     implementation('org.apache.commons:commons-lang3:3.19.0')
 
-    implementation('com.jayway.jsonpath:json-path')
-
     testImplementation('org.springframework.boot:spring-boot-starter-test')
     testImplementation platform('org.junit:junit-bom:5.13.4')
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/vividus-util/build.gradle
+++ b/vividus-util/build.gradle
@@ -52,13 +52,13 @@ dependencies {
     api('com.fasterxml.jackson.core:jackson-databind')
     api('com.fasterxml.jackson.datatype:jackson-datatype-jdk8')
     api('org.apache.commons:commons-lang3:3.19.0')
+    api("com.github.vividus-framework.JsonPath:json-path:${versions.jsonPath}")
 
     implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
 
     implementation('org.apache.commons:commons-collections4:4.5.0')
     implementation('commons-io:commons-io:2.20.0')
     implementation('com.fasterxml.jackson.dataformat:jackson-dataformat-properties')
-    implementation("com.github.vividus-framework.JsonPath:json-path:${versions.jsonPath}")
 
     testImplementation platform('org.junit:junit-bom:5.13.4')
     testImplementation('org.junit.jupiter:junit-jupiter')


### PR DESCRIPTION
Execution failed for task ':vividus-plugin-aws-secrets-manager:compileJava'.
> Compilation failed; see the compiler output below.
  /Users/runner/work/vividus/vividus/vividus-plugin-aws-secrets-manager/src/main/java/org/vividus/aws/secretsmanager/processor/AwsSecretsManagerPropertiesProcessor.java:91: error: cannot access DocumentContext
          return JsonPathUtils.getData(secretString, "$." + key);
                              ^
    class file for com.jayway.jsonpath.DocumentContext not found
  1 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined dependencies by removing redundant JSONPath libraries from multiple plugins and exporters.
  * Centralized JSONPath availability via the core utilities module to reduce duplication and improve consistency.
  * Reduced build/runtime footprint with fewer transitive dependencies.

* **Potential Impact**
  * If your project relied on JSONPath being provided transitively by individual plugins, add an explicit JSONPath dependency to your application to retain that functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->