### PR TITLE
[docs] Update visual steps naming in docs

### DIFF
--- a/docs/modules/plugins/pages/plugin-visual.adoc
+++ b/docs/modules/plugins/pages/plugin-visual.adoc
@@ -125,12 +125,12 @@ To use custom configuration per step, two new steps were implemented.
 
 [source,gherkin]
 ----
-When I $visualAction baseline with `$baselineName` using screenshot configuration:$screenshotConfiguration
+When I $visualAction baseline with name `$baselineName` using screenshot configuration:$screenshotConfiguration
 ----
 
 [source,gherkin]
 ----
-When I $visualAction baseline with `$baselineName` ignoring:$ignoringElement using screenshot configuration:$screenshotConfiguration
+When I $visualAction baseline with name `$baselineName` ignoring:$ignoringElement using screenshot configuration:$screenshotConfiguration
 ----
 
 ==== *Examples of usage property based web configuration:*
@@ -150,7 +150,7 @@ web.screenshot.strategy=custom
 
 [source,gherkin]
 ----
-When I <action> baseline with `scrollable-element-context` using screenshot configuration:
+When I <action> baseline with name `scrollable-element-context` using screenshot configuration:
 |scrollableElement                    |webHeaderToCut|webFooterToCut|scrollTimeout|shootingStrategy|
 |By.xpath(//div[@class="page__inner"])|80            |0             |PT1S         |SIMPLE          |
 ----
@@ -239,7 +239,7 @@ mobile.screenshot.strategy=custom
 
 [source,gherkin]
 ----
-When I <action> baseline with `scrollable-element-context` using screenshot configuration:
+When I <action> baseline with name `scrollable-element-context` using screenshot configuration:
 |cutTop           |shootingStrategy|
 |51               |VIEWPORT        |
 ----


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified Gherkin step wording in per-step configuration to “baseline with name <baselineName>” for both web and mobile contexts.
  - Updated related examples and references for consistency across the documentation.
  - No behavior changes; this is a wording and clarity update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->