### PR TITLE
Add ability to disable secret manager processors

### DIFF
--- a/docs/modules/configuration/pages/secrets-management.adoc
+++ b/docs/modules/configuration/pages/secrets-management.adoc
@@ -136,7 +136,7 @@ NOTE: The properties marked with *bold* are mandatory.
 |Example
 
 |[subs=+quotes]`*vault.uri*`
-|Vault enpoint
+|Vault endpoint
 |`http://127.0.0.1:8200`
 
 |[subs=+quotes]`*vault.token*`
@@ -150,6 +150,10 @@ Token authentication is just one of several authentication methods that are http
 |`vault.namespace`
 |Vault Enterprise allows using https://developer.hashicorp.com/vault/docs/enterprise/namespaces[namespaces] to isolate multiple Vaults on a single Vault server. This feature is not supported by Vault Community edition and has no effect on Vault operations.
 |`ns1/ns2`
+
+|[subs=+quotes]`*secrets-manager.vault.enabled*`
+|Defines whether VIVIDUS retrieves secrets from HashiCorp's Vault (`true` by default). If set to `false`, values from HashiCorp’s Vault will not be retrieved. Can be used when access to HashiCorp's Vault is restricted, e.g. for local debugging, to override only the required properties instead of all processed ones.
+|`false`
 
 |===
 

--- a/docs/modules/plugins/pages/plugin-aws-secrets-manager.adoc
+++ b/docs/modules/plugins/pages/plugin-aws-secrets-manager.adoc
@@ -9,6 +9,20 @@ include::partial$aws.adoc[]
 
 == How to refer AWS secrets
 
+=== Configuration
+
+[cols="1,1,3", options="header"]
+|===
+|Property name
+|Default
+|Description
+
+|[subs=+quotes]`secrets-manager.aws-secrets-manager.enabled`
+|`true`
+|Defines whether VIVIDUS retrieves secrets from AWS Secrets Manager. If set to `false`, values from AWS Secrets Manager will not be retrieved. Can be used when access to AWS Secrets Manager is restricted, e.g. for local debugging, to override only the required properties instead of all processed ones.
+
+|===
+
 . Find the required secret in the list.
 +
 image::aws_secrets.png[AWS Secrets]

--- a/docs/modules/plugins/pages/plugin-azure-resource-manager.adoc
+++ b/docs/modules/plugins/pages/plugin-azure-resource-manager.adoc
@@ -38,7 +38,7 @@ Azure subscription must be configured via `AZURE_SUBSCRIPTION_ID` environment va
 
 NOTE: The properties marked with *bold* are mandatory.
 
-[cols="3,1,1,3", options="header"]
+[cols="1,1,3", options="header"]
 |===
 |Property name
 |Default
@@ -51,6 +51,10 @@ NOTE: The properties marked with *bold* are mandatory.
 |[subs=+quotes]`secrets-manager.azure-key-vault.api-version`
 |`7.6`
 |Client API version
+
+|[subs=+quotes]`secrets-manager.azure-key-vault.enabled`
+|`true`
+|Defines whether VIVIDUS retrieves secrets from Azure Key Vault. If set to `false`, values from Azure Key Vault will not be retrieved. Can be used when access to Azure Key Vault is restricted, e.g. for local debugging, to override only the required properties instead of all processed ones.
 
 |===
 

--- a/vividus-engine/src/main/java/org/vividus/configuration/AbstractPropertiesProcessor.java
+++ b/vividus-engine/src/main/java/org/vividus/configuration/AbstractPropertiesProcessor.java
@@ -30,16 +30,21 @@ public abstract class AbstractPropertiesProcessor implements PropertiesProcessor
         this.propertyPattern = Pattern.compile("(" + processorRegexMarker + "\\((.+?)\\)" + ")");
     }
 
+    protected abstract boolean isEnabled(Properties properties);
+
     @Override
     public Properties processProperties(Properties properties)
     {
-        for (Map.Entry<Object, Object> entry : properties.entrySet())
+        if (isEnabled(properties))
         {
-            Object propertyValue = entry.getValue();
-            if (propertyValue instanceof String propertyValueAsString)
+            for (Map.Entry<Object, Object> entry : properties.entrySet())
             {
-                String newValue = processProperty((String) entry.getKey(), propertyValueAsString);
-                entry.setValue(newValue);
+                Object propertyValue = entry.getValue();
+                if (propertyValue instanceof String propertyValueAsString)
+                {
+                    String newValue = processProperty((String) entry.getKey(), propertyValueAsString);
+                    entry.setValue(newValue);
+                }
             }
         }
         return properties;

--- a/vividus-engine/src/test/java/org/vividus/configuration/PropertiesProcessorTests.java
+++ b/vividus-engine/src/test/java/org/vividus/configuration/PropertiesProcessorTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+class PropertiesProcessorTests
+{
+    private static final String PROCESSOR_ENABLED_PROPERTY = "secrets-manager.enabled";
+    private static final String KEY = "key";
+    private static final String TRUE = "true";
+
+    @Test
+    void shouldNotProcessPropertiesWhenProcessorDisabled()
+    {
+        var value = "value";
+        var processor = new TestProcessor();
+        Properties properties = new Properties();
+        properties.put(KEY, value);
+        assertEquals(value, processor.processProperties(properties).get(KEY));
+    }
+
+    @Test
+    void shouldProcessStringPropertyWhenProcessorEnabled()
+    {
+        var processor = new TestProcessor();
+        Properties properties = new Properties();
+        properties.put(PROCESSOR_ENABLED_PROPERTY, TRUE);
+        properties.put(KEY, "SECRET_MANAGER(value)");
+        assertEquals("VALUE", processor.processProperties(properties).get(KEY));
+    }
+
+    @Test
+    void shouldSkipProcessingOfPropertyWhenProcessorEnabled()
+    {
+        var value = 123;
+        var processor = new TestProcessor();
+        Properties properties = new Properties();
+        properties.put(PROCESSOR_ENABLED_PROPERTY, TRUE);
+        properties.put(KEY, value);
+        assertEquals(value, processor.processProperties(properties).get(KEY));
+    }
+
+    static class TestProcessor extends AbstractPropertiesProcessor
+    {
+        protected TestProcessor()
+        {
+            super("SECRET_MANAGER");
+        }
+
+        @Override
+        protected boolean isEnabled(Properties properties)
+        {
+            return Boolean.parseBoolean(properties.getProperty(PROCESSOR_ENABLED_PROPERTY));
+        }
+
+        @Override
+        protected String processValue(String propertyName, String partOfPropertyValueToProcess)
+        {
+            return partOfPropertyValueToProcess.toUpperCase();
+        }
+    }
+}

--- a/vividus-plugin-aws-secrets-manager/src/main/java/org/vividus/aws/secretsmanager/processor/AwsSecretsManagerPropertiesProcessor.java
+++ b/vividus-plugin-aws-secrets-manager/src/main/java/org/vividus/aws/secretsmanager/processor/AwsSecretsManagerPropertiesProcessor.java
@@ -17,6 +17,7 @@
 package org.vividus.aws.secretsmanager.processor;
 
 import java.time.Duration;
+import java.util.Properties;
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
@@ -37,6 +38,7 @@ public class AwsSecretsManagerPropertiesProcessor extends AbstractPropertiesProc
     private static final String PATH_SEPARATOR = "/";
     private static final String AWS_DEFAULT_PROFILE = "default";
     private static final String PROPERTY_REGEX = "([^\\s]+?\\s*,\\s*)?[^\\s]+/[^\\s]+";
+    private static final String PROCESSOR_ENABLED_PROPERTY = "secrets-manager.aws-secrets-manager.enabled";
 
     private final LoadingCache<SecretId, String> secretsCache = CacheBuilder.newBuilder()
             .expireAfterWrite(Duration.ofMinutes(1)).build(new CacheLoader<>()
@@ -66,6 +68,12 @@ public class AwsSecretsManagerPropertiesProcessor extends AbstractPropertiesProc
     public AwsSecretsManagerPropertiesProcessor()
     {
         super("AWS_SECRETS_MANAGER");
+    }
+
+    @Override
+    public boolean isEnabled(Properties properties)
+    {
+        return Boolean.parseBoolean(properties.getProperty(PROCESSOR_ENABLED_PROPERTY));
     }
 
     @Override

--- a/vividus-plugin-aws-secrets-manager/src/main/resources/properties.defaults/default.properties
+++ b/vividus-plugin-aws-secrets-manager/src/main/resources/properties.defaults/default.properties
@@ -1,0 +1,1 @@
+secrets-manager.aws-secrets-manager.enabled=true

--- a/vividus-plugin-aws-secrets-manager/src/test/java/org/vividus/aws/secretsmanager/processor/AwsSecretsManagerPropertiesProcessorTests.java
+++ b/vividus-plugin-aws-secrets-manager/src/test/java/org/vividus/aws/secretsmanager/processor/AwsSecretsManagerPropertiesProcessorTests.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import java.util.Properties;
+
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClient;
@@ -89,5 +91,13 @@ class AwsSecretsManagerPropertiesProcessorTests
                 () -> processor.processValue("test", "invalid-format"));
         assertEquals("The expected property value format is AWS_SECRETS_MANAGER(profile, secret/secret_key) "
                 + "or AWS_SECRETS_MANAGER(secret/secret_key)", exception.getMessage());
+    }
+
+    @Test
+    void shouldNotProcessPropertiesWhenProcessorDisabled()
+    {
+        var properties = new Properties();
+        properties.put("property", "AWS_SECRETS_MANAGER(profile, secret/test)");
+        assertEquals(properties, processor.processProperties(properties));
     }
 }

--- a/vividus-plugin-azure-resource-manager/src/main/java/org/vividus/azure/configuration/AzureKeyVaultPropertiesProcessor.java
+++ b/vividus-plugin-azure-resource-manager/src/main/java/org/vividus/azure/configuration/AzureKeyVaultPropertiesProcessor.java
@@ -35,6 +35,7 @@ public class AzureKeyVaultPropertiesProcessor extends AbstractPropertiesProcesso
     private static final String ENVIRONMENT_PROPERTY = "azure.environment";
     private static final String KEY_VAULT_NAME_PROPERTY = "secrets-manager.azure-key-vault.name";
     private static final String KEY_VAULT_API_VERSION_PROPERTY = "secrets-manager.azure-key-vault.api-version";
+    private static final String KEY_VAULT_PROCESSOR_ENABLED_PROPERTY = "secrets-manager.azure-key-vault.enabled";
 
     private static final Map<String, AzureEnvironment> ENVIRONMENT_MAP = Map.of(
             "AZURE", AzureEnvironment.AZURE,
@@ -50,6 +51,12 @@ public class AzureKeyVaultPropertiesProcessor extends AbstractPropertiesProcesso
     public AzureKeyVaultPropertiesProcessor()
     {
         super("AZURE_KEY_VAULT");
+    }
+
+    @Override
+    public boolean isEnabled(Properties properties)
+    {
+        return Boolean.parseBoolean(properties.getProperty(KEY_VAULT_PROCESSOR_ENABLED_PROPERTY));
     }
 
     @Override

--- a/vividus-plugin-azure-resource-manager/src/main/resources/properties.defaults/default.properties
+++ b/vividus-plugin-azure-resource-manager/src/main/resources/properties.defaults/default.properties
@@ -1,1 +1,2 @@
 secrets-manager.azure-key-vault.api-version=7.5
+secrets-manager.azure-key-vault.enabled=true

--- a/vividus/src/main/java/org/vividus/configuration/EncryptedPropertiesProcessor.java
+++ b/vividus/src/main/java/org/vividus/configuration/EncryptedPropertiesProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,12 @@ public class EncryptedPropertiesProcessor extends AbstractPropertiesProcessor
     public EncryptedPropertiesProcessor()
     {
         super(ENC);
+    }
+
+    @Override
+    protected boolean isEnabled(Properties properties)
+    {
+        return true;
     }
 
     @Override

--- a/vividus/src/main/java/org/vividus/configuration/VaultStoredPropertiesProcessor.java
+++ b/vividus/src/main/java/org/vividus/configuration/VaultStoredPropertiesProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public class VaultStoredPropertiesProcessor extends AbstractPropertiesProcessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(VaultStoredPropertiesProcessor.class);
     private static final Pattern SECRET_PATTERN = Pattern.compile("(?<engine>[^/]+)/(?<path>.+)/(?<key>[^/]+)$");
+    private static final String VAULT_PROCESSOR_ENABLED_PROPERTY = "secrets-manager.vault.enabled";
 
     private Properties properties;
     private VaultTemplate vaultTemplate;
@@ -46,6 +47,12 @@ public class VaultStoredPropertiesProcessor extends AbstractPropertiesProcessor
     public VaultStoredPropertiesProcessor()
     {
         super("(?<!AZURE_KEY_)(?:VAULT|HASHI_CORP_VAULT)");
+    }
+
+    @Override
+    public boolean isEnabled(Properties properties)
+    {
+        return Boolean.parseBoolean(properties.getProperty(VAULT_PROCESSOR_ENABLED_PROPERTY));
     }
 
     @Override

--- a/vividus/src/main/resources/properties/defaults/default.properties
+++ b/vividus/src/main/resources/properties/defaults/default.properties
@@ -104,3 +104,5 @@ report.brand.logo-path=/allure-plugins/vividus-logo/vividus-logo.svg
 report.brand.title=VIVIDUS
 report.tabs.custom-tab.enabled=false
 report.translations.en.tab.custom-tab.name=Custom tab
+
+secrets-manager.vault.enabled=true

--- a/vividus/src/test/java/org/vividus/configuration/VaultStoredPropertiesProcessorTests.java
+++ b/vividus/src/test/java/org/vividus/configuration/VaultStoredPropertiesProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,15 +80,12 @@ class VaultStoredPropertiesProcessorTests
     })
     void shouldRejectInvalidSecretPaths(String fullSecretPath) throws IOException
     {
-        try (var processor = new VaultStoredPropertiesProcessor())
-        {
-            var propertyName = "invalid-property";
-            var exception = assertThrows(IllegalArgumentException.class,
-                    () -> processor.processValue(propertyName, fullSecretPath));
-            assertEquals(
-                    "Full secret path must follow pattern 'engine/path_with_separators/key', but '" + fullSecretPath
-                            + "' was found in property '" + propertyName + "'", exception.getMessage());
-        }
+        var propertyName = "invalid-property";
+        var exception = assertThrows(IllegalArgumentException.class,
+                () -> new VaultStoredPropertiesProcessor().processValue(propertyName, fullSecretPath));
+        assertEquals(
+                "Full secret path must follow pattern 'engine/path_with_separators/key', but '" + fullSecretPath
+                        + "' was found in property '" + propertyName + "'", exception.getMessage());
     }
 
     @Test
@@ -178,10 +175,7 @@ class VaultStoredPropertiesProcessorTests
     })
     void shouldPrintLogAboutDeprecation(String propertyValue) throws IOException
     {
-        try (var processor = new VaultStoredPropertiesProcessor())
-        {
-            processor.processProperty("old-property-name", propertyValue);
-        }
+        new VaultStoredPropertiesProcessor().processProperty("old-property-name", propertyValue);
         assertThat(logger.getLoggingEvents(), is(List.of(
                 warn("`VAULT(...)` placeholder is deprecated and will be removed in VIVIDUS 0.7.0, "
                         + "please use `HASHI_CORP_VAULT(...)` placeholder instead."))));
@@ -196,10 +190,15 @@ class VaultStoredPropertiesProcessorTests
     })
     void shouldNotPrintLogAboutDeprecation(String propertyValue) throws IOException
     {
-        try (var processor = new VaultStoredPropertiesProcessor())
-        {
-            processor.processProperty("new-property-name", propertyValue);
-        }
+        new VaultStoredPropertiesProcessor().processProperty("new-property-name", propertyValue);
         assertEquals(0, logger.getLoggingEvents().size());
+    }
+
+    @Test
+    void shouldNotProcessPropertiesWhenProcessorDisabled() throws IOException
+    {
+        var properties = new Properties();
+        properties.put("property", "HASHI_CORP_VAULT(secret/vividus/test/username)");
+        assertEquals(properties, new VaultStoredPropertiesProcessor().processProperties(properties));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed "Vault endpoint" typo; expanded configuration and usage examples for AWS Secrets Manager and Azure Key Vault; retained deprecation note for VAULT(...).

* **New Features**
  * Per-secrets-manager enable/disable flags added for AWS Secrets Manager (default: enabled), Azure Key Vault (default: enabled), and Vault (default: enabled).

* **Tests**
  * Added/updated tests covering processor enabled/disabled behavior and string vs non-string value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->