### PR TITLE
[tests] Use iPad (8th generation) for SauceLabs web tablet tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -560,7 +560,7 @@ jobs:
                                                   -Pvividus.configuration.profiles=saucelabs/web,web/tablet/${profile} \
                                                   -Pvividus.configuration.suites=system \
                                                   -Pvividus.batch-1.resource-include-patterns=HealthCheck.story,IPadVisualStepsTests.story \
-                                                  -Pvividus.selenium.grid.capabilities.deviceName="iPad (7th generation) Simulator" \
+                                                  -Pvividus.selenium.grid.capabilities.deviceName="iPad (8th generation) Simulator" \
                                                   -Pvividus.selenium.grid.username=${SAUCELABS_USER} \
                                                   -Pvividus.selenium.grid.password=${SAUCELABS_KEY}
           done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing configuration to use a newer iPad simulator for tablet web tests, improving coverage for current devices.
  * No changes to app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->