### PR TITLE
[tests] Fix flaky HTTP integration test for multipart requests

### DIFF
--- a/vividus-tests/src/main/resources/story/integration/HTTP.story
+++ b/vividus-tests/src/main/resources/story/integration/HTTP.story
@@ -100,7 +100,7 @@ Given multipart request:
 |file  |file-key2 |${temp-file-path}|text/plain |               |
 |string|string-key|string1          |text/plain |               |
 |binary|binary-key|raw              |text/plain |raw.txt        |
-When I execute HTTP POST request for resource with URL `https://httpbin.org/post`
+When I execute HTTP POST request for resource with URL `https://httpbingo.org/post`
 Then `${responseCode}` is equal to `200`
 Then JSON element from `${json-context}` by JSON path `$.files.file-key` is equal to `"#{loadResource(/data/file.txt)}"`
 Then JSON element from `${json-context}` by JSON path `$.files.file-key2` is equal to `"${temp-file-content}"`


### PR DESCRIPTION
https://httpbin.org/ is unstable and often returns an error "503 Service Temporarily Unavailable", the test is updated to use https://httpbingo.org/ which is much more stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP testing infrastructure endpoints to ensure consistent test execution across integration test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->