### PR TITLE
Bump JBehave from `6.0.0-alpha.9` to `6.0.0-alpha.10`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ project.description = 'Vividus'
 
 ext {
     versions = [
-        jbehave:                '6.0.0-alpha.9',
+        jbehave:                '6.0.0-alpha.10',
         powermock:              'a0be5c4bbe',
         jsonPath:               'eec830ced9'
     ]


### PR DESCRIPTION
Changelog:
 - JBEHAVE-1611 Add ability to use `@Parameter` annotation in parent classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version to the latest alpha release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->