### PR TITLE
[engine] Delegate asPlainString(..) invocation in step decorator

### DIFF
--- a/vividus-engine/src/main/java/org/vividus/steps/SubSteps.java
+++ b/vividus-engine/src/main/java/org/vividus/steps/SubSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,12 @@ public class SubSteps
         public String asString(Keywords keywords)
         {
             return step.asString(keywords);
+        }
+
+        @Override
+        public String asPlainString(Keywords keywords)
+        {
+            return step.asPlainString(keywords);
         }
 
         @Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ensure consistent delegation for plain-string conversion so step objects return the same plain-string representation as their string conversion.

* **Tests**
  * Added tests to verify delegation of plain-string conversion and updated test setup to reuse common configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->