### PR TITLE
[tests] Bump version of mobile test app to `0.8.1` for SauceLabs tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -493,7 +493,7 @@ jobs:
   system-mobile-tests-on-saucelabs:
     if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     env:
-      TEST_APP_VERSION: 0.8.0
+      TEST_APP_VERSION: 0.8.1
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -493,7 +493,7 @@ jobs:
   system-mobile-tests-on-saucelabs:
     if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     env:
-      TEST_APP_VERSION: 0.7.0
+      TEST_APP_VERSION: 0.8.0
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI testing configuration to use test app version 0.8.1 (replacing 0.7.0), ensuring test runs reference the newer app build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->