### PR TITLE
Add ssl option for rabbimq config

### DIFF
--- a/docs/modules/plugins/pages/plugin-rabbitmq.adoc
+++ b/docs/modules/plugins/pages/plugin-rabbitmq.adoc
@@ -43,6 +43,11 @@ NOTE: The broker key must not contain dots.
 |
 |The logical broker namespace (https://www.rabbitmq.com/docs/vhosts[vhost]) for connections, exchanges, and queues.
 
+|`rabbitmq.<broker-key>.use-ssl`
+|`true` / `false`
+|`false`
+|Enables an encrypted (TLS) connection to the broker.
+
 |===
 
 .Local connection

--- a/vividus-plugin-rabbitmq/src/main/java/org/vividus/steps/rabbitmq/RabbitMqSteps.java
+++ b/vividus-plugin-rabbitmq/src/main/java/org/vividus/steps/rabbitmq/RabbitMqSteps.java
@@ -23,12 +23,16 @@ import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.net.ssl.SSLContext;
+
+import org.apache.commons.lang3.Validate;
 import org.jbehave.core.annotations.When;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -72,9 +76,30 @@ public class RabbitMqSteps
         getOptional(connectionProperties, "username").ifPresent(connectionFactory::setUsername);
         getOptional(connectionProperties, "password").ifPresent(connectionFactory::setPassword);
         getOptional(connectionProperties, "virtual-host").ifPresent(connectionFactory::setVirtualHost);
+        getOptional(connectionProperties, "use-ssl").ifPresent(value ->
+        {
+            Validate.isTrue("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value),
+                    "Invalid value '%s' for rabbitmq.<broker-key>.use-ssl, expected true/false", value);
+            if (Boolean.parseBoolean(value))
+            {
+                enableSsl(connectionFactory);
+            }
+        });
         RabbitTemplate template = new RabbitTemplate(connectionFactory);
         template.setMandatory(false);
         return template;
+    }
+
+    private static void enableSsl(CachingConnectionFactory factory)
+    {
+        try
+        {
+            factory.getRabbitConnectionFactory().useSslProtocol(SSLContext.getDefault());
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            throw new IllegalStateException(e);
+        }
     }
 
     private static Optional<String> getOptional(Map<String, String> properties, String key)

--- a/vividus-plugin-rabbitmq/src/test/java/org/vividus/steps/rabbitmq/RabbitMqStepsTests.java
+++ b/vividus-plugin-rabbitmq/src/test/java/org/vividus/steps/rabbitmq/RabbitMqStepsTests.java
@@ -20,16 +20,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+
+import javax.net.ssl.SSLContext;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,6 +59,7 @@ class RabbitMqStepsTests
     private static final String SUFFIX_USERNAME = ".username";
     private static final String SUFFIX_PASSWORD = ".password";
     private static final String SUFFIX_VIRTUAL_HOST = ".virtual-host";
+    private static final String SUFFIX_USE_SSL = ".use-ssl";
 
     private static final String MESSAGE_BODY = "msg";
     private static final String ROUTING_KEY = "rk";
@@ -132,6 +138,59 @@ class RabbitMqStepsTests
             verify(variableContext).putVariable(Set.of(VariableScope.STEP), VARIABLE_N, "42");
             verify(softAssert).assertNotNull(description, 42);
             verify(factories.constructed().get(0), never()).setPort(anyInt());
+        });
+    }
+
+    @Test
+    void shouldEnableSslUsingDefaultJvmContext() throws NoSuchAlgorithmException
+    {
+        var rabbitConnFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+        try (var factories = mockConstruction(CachingConnectionFactory.class,
+                     (mock, ctx) -> when(mock.getRabbitConnectionFactory()).thenReturn(rabbitConnFactory));
+                var ignored = mockConstruction(RabbitTemplate.class))
+        {
+            createSteps(Map.of(BROKER + SUFFIX_HOST, HOST_LOCAL, BROKER + SUFFIX_USE_SSL, Boolean.TRUE.toString()));
+            verify(rabbitConnFactory).useSslProtocol(SSLContext.getDefault());
+        }
+    }
+
+    @Test
+    void shouldWrapNoSuchAlgorithmExceptionFromSslContext()
+    {
+        var cause = new NoSuchAlgorithmException("no-tls");
+        try (var sslContext = mockStatic(SSLContext.class);
+                var ignored1 = mockConstruction(CachingConnectionFactory.class,
+                        (mock, ctx) -> when(mock.getRabbitConnectionFactory())
+                                .thenReturn(mock(com.rabbitmq.client.ConnectionFactory.class)));
+                var ignored2 = mockConstruction(RabbitTemplate.class))
+        {
+            sslContext.when(SSLContext::getDefault).thenThrow(cause);
+            var props = Map.of(BROKER + SUFFIX_HOST, HOST_LOCAL, BROKER + SUFFIX_USE_SSL, Boolean.TRUE.toString());
+            var exception = assertThrows(IllegalStateException.class, () -> createSteps(props));
+            assertEquals(cause, exception.getCause());
+        }
+    }
+
+    @Test
+    void shouldNotEnableSslWhenFlagIsFalse()
+    {
+        withMockedRabbit((factories, templates) ->
+        {
+            createSteps(Map.of(BROKER + SUFFIX_HOST, HOST_LOCAL, BROKER + SUFFIX_USE_SSL, "false"));
+            verify(factories.constructed().get(0), never()).getRabbitConnectionFactory();
+        });
+    }
+
+    @Test
+    void shouldFailWhenUseSslValueIsNotBoolean()
+    {
+        withMockedRabbit((factories, templates) ->
+        {
+            var props = Map.of(BROKER + SUFFIX_HOST, HOST_LOCAL, BROKER + SUFFIX_USE_SSL, "yes");
+            var exception = assertThrows(IllegalArgumentException.class, () -> createSteps(props));
+            assertEquals(
+                    "Invalid value 'yes' for rabbitmq.<broker-key>.use-ssl, expected true/false",
+                    exception.getMessage());
         });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration property rabbitmq.<broker-key>.use-ssl (true/false, default: false) to enable encrypted (TLS) connections to RabbitMQ brokers.

* **Tests**
  * Added test coverage for SSL/TLS enablement, validation of the new property’s accepted values, and related error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->