### PR TITLE
Add file polling step

### DIFF
--- a/docs/modules/commons/pages/vividus-steps.adoc
+++ b/docs/modules/commons/pages/vividus-steps.adoc
@@ -472,6 +472,28 @@ Examples:
 file:///${examples-table-temporary-file}
 ----
 
+=== Wait for a file to appear in a directory
+
+Polls the given directory until exactly one file whose name matches the regular expression appears or the timeout
+expires, then saves the absolute path of that file to a variable.
+
+[source,gherkin]
+----
+When I wait `$timeout` with `$pollingTimeout` polling until file matching `$fileNameRegex` appears in directory `$directoryPath` and save path to $scopes variable `$variableName`
+----
+
+* `$timeout` - The maximum time to wait in {durations-format-link} format.
+* `$pollingTimeout` - The interval between polling attempts in {durations-format-link} format.
+* `$fileNameRegex` - The regular expression matched against file names only (not the full path), e.g. `report-\d+\.csv`.
+* `$directoryPath` - The path to an existing directory to watch.
+* `$scopes` - xref:commons:variables.adoc#_scopes[The comma-separated set of the variables scopes].
+* `$variableName` - The name of the variable to store the absolute path of the matched file.
+
+.Wait up to 30 seconds for a CSV report to arrive and store its path
+[source,gherkin]
+----
+When I wait `PT30S` with `PT1S` polling until file matching `report-\d+\.csv` appears in directory `/tmp/reports` and save path to SCENARIO variable `report-path`
+----
 
 == ZIP archives
 === Save ZIP archive entries

--- a/vividus-tests/src/main/resources/story/integration/FileSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/FileSteps.story
@@ -1,0 +1,5 @@
+Scenario: Validate step "When I wait `$timeout` with `$pollingTimeout` polling until file matching `$fileNameRegex` appears in directory `$directoryPath` and save path to $scopes variable `$variableName`"
+When I create temporary file with name `mydata.txt` and content `Hello World!` and put path to scenario variable `filePath`
+Given I initialize scenario variable `folderName` with value `#{eval(stringUtils:substringBefore(filePath, 'mydata'))}`
+When I wait `PT30S` with `PT1S` polling until file matching `mydata.*.txt` appears in directory `${folderName}` and save path to scenario variable `textFile`
+Then `${textFile}` is equal to `${filePath}`

--- a/vividus/src/main/java/org/vividus/steps/FileSteps.java
+++ b/vividus/src/main/java/org/vividus/steps/FileSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +21,32 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.Validate;
 import org.jbehave.core.annotations.When;
 import org.vividus.context.VariableContext;
+import org.vividus.softassert.ISoftAssert;
 import org.vividus.util.ResourceUtils;
+import org.vividus.util.wait.DurationBasedWaiter;
 import org.vividus.variable.VariableScope;
-
-import jakarta.inject.Inject;
 
 public class FileSteps
 {
-    @Inject private VariableContext variableContext;
+    private final VariableContext variableContext;
+    private final ISoftAssert softAssert;
+
+    public FileSteps(VariableContext variableContext, ISoftAssert softAssert)
+    {
+        this.variableContext = variableContext;
+        this.softAssert = softAssert;
+    }
 
     /**
      * Creates temporary file with specified content and puts path to that file to variable with specified name.
@@ -73,5 +85,51 @@ public class FileSteps
     public void createFile(String fileContent, String filePath) throws IOException
     {
         FileUtils.writeStringToFile(new File(filePath), fileContent, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Polls the given directory until exactly one file whose name matches the regular expression appears or the timeout
+     * expires, then saves the absolute path of the matched file to a variable. Fails if more than one matching file
+     * is found.
+     * @param timeout        The maximum time to wait in {durations-format-link} format
+     * @param pollingTimeout The interval between polling attempts in {durations-format-link} format
+     * @param fileNameRegex  The regular expression to match against file names (e.g. {@code report-\d+\.csv})
+     * @param directoryPath  The path to the directory to watch
+     * @param scopes         The set of variable scopes
+     * @param variableName   The variable name to store the absolute file path
+     * @throws IOException If an I/O error has occurred while reading the directory
+     */
+    @When("I wait `$timeout` with `$pollingTimeout` polling until file matching `$fileNameRegex` appears in directory "
+            + "`$directoryPath` and save path to $scopes variable `$variableName`")
+    public void waitForFileAndSavePath(Duration timeout, Duration pollingTimeout, Pattern fileNameRegex,
+            Path directoryPath, Set<VariableScope> scopes, String variableName) throws IOException
+    {
+        Validate.isTrue(Files.isDirectory(directoryPath), "The directory '%s' does not exist", directoryPath);
+
+        List<Path> found = new DurationBasedWaiter(timeout, pollingTimeout).wait(() ->
+        {
+            try (Stream<Path> paths = Files.list(directoryPath))
+            {
+                return paths.filter(Files::isRegularFile)
+                        .filter(p -> fileNameRegex.matcher(p.getFileName().toString()).matches()).toList();
+            }
+        }, matches -> !matches.isEmpty());
+
+        if (found.size() > 1)
+        {
+            List<String> fileNames = found.stream().map(Path::getFileName).map(Path::toString).sorted().toList();
+            softAssert
+                    .recordFailedAssertion("Expected exactly 1 file matching `%s` in directory '%s', but found %d: %s."
+                            .formatted(fileNameRegex, directoryPath, found.size(), String.join(", ", fileNames)));
+        }
+        else if (found.isEmpty())
+        {
+            softAssert.recordFailedAssertion("No file matching `%s` appeared in directory '%s' within %s"
+                    .formatted(fileNameRegex, directoryPath, timeout));
+        }
+        else
+        {
+            variableContext.putVariable(scopes, variableName, found.get(0).toAbsolutePath().toString());
+        }
     }
 }

--- a/vividus/src/test/java/org/vividus/steps/FileStepsTests.java
+++ b/vividus/src/test/java/org/vividus/steps/FileStepsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,32 +17,44 @@
 package org.vividus.steps;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.vividus.context.VariableContext;
+import org.vividus.softassert.ISoftAssert;
 import org.vividus.variable.VariableScope;
 
 @ExtendWith(MockitoExtension.class)
 class FileStepsTests
 {
-    @Mock
-    private VariableContext variableContext;
+    private static final Pattern FILE_PATTERN = Pattern.compile("report-\\d+\\.csv");
+    private static final Set<VariableScope> SCOPES = Set.of(VariableScope.SCENARIO);
+    private static final String VARIABLE = "file-path";
+    private static final Duration TIMEOUT = Duration.ZERO;
+
+    @Mock private VariableContext variableContext;
+    @Mock private ISoftAssert softAssert;
 
     @InjectMocks
     private FileSteps fileSteps;
@@ -74,5 +86,50 @@ class FileStepsTests
         String fileContent = "file-content";
         fileSteps.createFile(fileContent, tempFilePath);
         assertEquals(fileContent, FileUtils.readFileToString(new File(tempFilePath), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void shouldFailWhenDirectoryDoesNotExist()
+    {
+        var path = Path.of("non/existent/dir");
+        var exception = assertThrows(IllegalArgumentException.class,
+                () -> fileSteps.waitForFileAndSavePath(TIMEOUT, TIMEOUT, FILE_PATTERN, path, SCOPES, VARIABLE));
+        assertEquals("The directory '%s' does not exist".formatted(path), exception.getMessage());
+        verifyNoInteractions(variableContext, softAssert);
+    }
+
+    @Test
+    void shouldSaveFilePathWhenExactlyOneFileMatches(@TempDir Path tempDir) throws IOException
+    {
+        String csv = "report-42.csv";
+        Files.createFile(tempDir.resolve(csv));
+        fileSteps.waitForFileAndSavePath(TIMEOUT, TIMEOUT, FILE_PATTERN, tempDir, SCOPES, VARIABLE);
+        verify(variableContext).putVariable(SCOPES, VARIABLE, tempDir.resolve(csv).toAbsolutePath().toString());
+        verifyNoInteractions(softAssert);
+    }
+
+    @Test
+    void shouldFailWhenNoFileAppearsWithinTimeout(@TempDir Path tempDir) throws IOException
+    {
+        fileSteps.waitForFileAndSavePath(TIMEOUT, TIMEOUT, FILE_PATTERN, tempDir, SCOPES, VARIABLE);
+        verify(softAssert).recordFailedAssertion(
+                "No file matching `%s` appeared in directory '%s' within %s"
+                        .formatted(FILE_PATTERN, tempDir, TIMEOUT));
+        verifyNoInteractions(variableContext);
+    }
+
+    @Test
+    void shouldFailWhenMultipleFilesMatch(@TempDir Path tempDir) throws IOException
+    {
+        Files.createFile(tempDir.resolve("report-1.csv"));
+        Files.createFile(tempDir.resolve("report-2.csv"));
+        fileSteps.waitForFileAndSavePath(TIMEOUT, TIMEOUT, FILE_PATTERN, tempDir, SCOPES, VARIABLE);
+        var messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(softAssert).recordFailedAssertion(messageCaptor.capture());
+        assertEquals(
+                "Expected exactly 1 file matching `%s` in directory '%s', but found 2: report-1.csv, report-2.csv."
+                        .formatted(FILE_PATTERN, tempDir),
+                messageCaptor.getValue());
+        verifyNoInteractions(variableContext);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a step to wait for a file matching a name pattern to appear in a directory with configurable timeout and polling; when exactly one match appears, its absolute path is saved to a variable.

* **Documentation**
  * Added docs and a Gherkin example showing timeout, polling, regex matching, and variable storage.

* **Tests**
  * Added unit and integration tests for success, timeout/no-match, multiple-match, and non-directory cases with clear assertion messages.

* **Bug Fixes**
  * Improved validation and failure reporting for directory, no-match, and multi-match scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->