### PR TITLE
[tests] Fix flaky system tests for native mobile apps

### DIFF
--- a/vividus-tests/src/main/resources/properties/environment/system/saucelabs/mobile_app/environment.properties
+++ b/vividus-tests/src/main/resources/properties/environment/system/saucelabs/mobile_app/environment.properties
@@ -1,1 +1,2 @@
 variables.appType=mobile_app
+ui.search.wait-for-element-timeout=PT5S

--- a/vividus-tests/src/main/resources/story/system/mobile_app/MobileAppStepsTests.story
+++ b/vividus-tests/src/main/resources/story/system/mobile_app/MobileAppStepsTests.story
@@ -225,7 +225,6 @@ When I tap on element located by `accessibilityId(menuToggler)`
 When I tap on element located by `xpath(//android.widget.TextView[@text='Image'])`
 When I upload file `/data/mobile-upload-image.png` to device
 When I tap on element located by `accessibilityId(selectImage)`
-When I wait until element located by `xpath(//android.widget.TextView[@text='Pictures'])` appears
 When I tap on element located by `xpath(//android.widget.TextView[@text='Pictures'])`
 When I tap on element located by `xpath((//android.view.ViewGroup[contains(@content-desc, "Photo taken")])[1])`
 Then number of elements found by `xpath(//android.widget.TextView[@text='228x228'])` is equal to `1`
@@ -238,7 +237,6 @@ When I tap on element located by `accessibilityId(menuToggler)`
 When I tap on element located by `iosClassChain(**/XCUIElementTypeButton[$name == "Image"$])`
 When I upload file `/data/mobile-upload-image.png` to device
 When I tap on element located by `iosNsPredicate(name == 'selectImage')`
-When I wait until element located by `accessibilityId(Photos)` appears
 When I tap on element located by `xpath((//XCUIElementTypeImage[contains(@name, "Photo")])[1])`
 When I wait until element located by `xpath(//XCUIElementTypeStaticText[@value='228x228'])` appears
 
@@ -248,7 +246,6 @@ Meta:
     @targetPlatform android
 When I upload file with name `file_for_upload_step.png` and data `#{loadBinaryResource(/data/file_for_upload_step.png)}` to device
 When I tap on element located by `accessibilityId(selectImage)`
-When I wait until element located by `xpath(//android.widget.TextView[@text='Pictures'])` appears
 When I tap on element located by `xpath(//android.widget.TextView[@text='Pictures'])`
 When I tap on element located by `xpath((//android.view.ViewGroup[contains(@content-desc, "Photo taken")])[1])`
 Then number of elements found by `xpath(//android.widget.TextView[@text='569x407'])` is equal to `1`
@@ -259,7 +256,6 @@ Meta:
     @targetPlatform ios
 When I upload file with name `file_for_upload_step.png` and data `#{loadBinaryResource(/data/file_for_upload_step.png)}` to device
 When I tap on element located by `iosNsPredicate(name == 'selectImage')`
-When I wait until element located by `accessibilityId(Photos)` appears
 When I tap on element located by `xpath((//XCUIElementTypeImage[contains(@name, "Photo")])[1])`
 Then number of elements found by `xpath(//XCUIElementTypeStaticText[@value='569x407'])` is equal to `1`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Added configurable timeout setting (5 seconds) for UI element search operations in Saucelabs mobile app environment.

* **Tests**
  * Streamlined mobile app upload test scenarios for Android and iOS by removing redundant wait steps, enabling more efficient test execution through centralized timeout configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->