### PR TITLE
Add message queue properties

### DIFF
--- a/docs/modules/plugins/pages/plugin-rabbitmq.adoc
+++ b/docs/modules/plugins/pages/plugin-rabbitmq.adoc
@@ -72,6 +72,26 @@ rabbitmq.cloudamqp.virtual-host=bob
 
 == Steps
 
+=== Set message properties
+
+Sets the AMQP message properties to be applied to the next <<_publish_message,published message>>. The properties are consumed after publishing and do not carry over to subsequent publish steps.
+
+[source,gherkin]
+----
+When I set RabbitMQ message properties:$properties
+----
+
+* `$properties` - The message properties table. The table must contain exactly one row. Column names map directly to the writable properties of https://www.rabbitmq.com/docs/publishers#message-properties[MessageProperties], for example `contentType`, `contentEncoding`, `correlationId`, `replyTo`, `expiration`, `messageId`, `type`, `userId`, `appId`.
+
+.Publish a JSON message with a correlation ID
+[source,gherkin]
+----
+When I set RabbitMQ message properties:
+|contentType     |correlationId|
+|application/json|req-42       |
+When I publish message `{"key":"value"}` with routing key `my-queue` to RabbitMQ broker `local`
+----
+
 === Publish message
 
 Sends the message text to the broker. The routing key is usually the queue name when you publish straight to a queue.

--- a/vividus-plugin-rabbitmq/src/main/java/org/vividus/steps/rabbitmq/RabbitMqSteps.java
+++ b/vividus-plugin-rabbitmq/src/main/java/org/vividus/steps/rabbitmq/RabbitMqSteps.java
@@ -26,6 +26,7 @@ import static org.apache.commons.lang3.StringUtils.substringBefore;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -34,10 +35,14 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.commons.lang3.Validate;
 import org.jbehave.core.annotations.When;
+import org.jbehave.core.model.ExamplesTable;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.vividus.context.VariableContext;
 import org.vividus.softassert.ISoftAssert;
+import org.vividus.testcontext.TestContext;
 import org.vividus.util.property.IPropertyParser;
 import org.vividus.variable.VariableScope;
 
@@ -45,13 +50,18 @@ public class RabbitMqSteps
 {
     private static final String DOT = ".";
 
+    private static final Class<?> MESSAGE_PROPERTIES_KEY = MessageProperties.class;
+
     private final Map<String, RabbitTemplate> rabbitTemplates;
+    private final TestContext testContext;
     private final VariableContext variableContext;
     private final ISoftAssert softAssert;
 
-    public RabbitMqSteps(IPropertyParser propertyParser, VariableContext variableContext, ISoftAssert softAssert)
+    public RabbitMqSteps(IPropertyParser propertyParser, TestContext testContext, VariableContext variableContext,
+            ISoftAssert softAssert)
     {
         this.rabbitTemplates = buildTemplates(propertyParser);
+        this.testContext = testContext;
         this.variableContext = variableContext;
         this.softAssert = softAssert;
     }
@@ -108,6 +118,21 @@ public class RabbitMqSteps
     }
 
     /**
+     * Sets the AMQP message properties to be applied to the next published message. The properties are consumed after
+     * publishing and do not carry over to subsequent publish steps.
+     *
+     * @param properties The message properties table.
+     */
+    @When("I set RabbitMQ message properties:$properties")
+    public void setMessageProperties(ExamplesTable properties)
+    {
+        List<MessageProperties> rows = properties.getRowsAs(MessageProperties.class);
+        Validate.isTrue(rows.size() == 1, "Exactly one row is expected in the message properties table, but got %d",
+                rows.size());
+        testContext.put(MESSAGE_PROPERTIES_KEY, rows.get(0));
+    }
+
+    /**
      * Publishes a text message to the default exchange with the given routing key (typically the queue name).
      *
      * @param message    The message body
@@ -117,7 +142,12 @@ public class RabbitMqSteps
     @When("I publish message `$message` with routing key `$routingKey` to RabbitMQ broker `$brokerKey`")
     public void publishMessage(String message, String routingKey, String brokerKey)
     {
-        getTemplate(brokerKey).convertAndSend(routingKey, message);
+        RabbitTemplate template = getTemplate(brokerKey);
+        MessageProperties messageProperties = Optional
+                .ofNullable(testContext.<MessageProperties>remove(MESSAGE_PROPERTIES_KEY))
+                .orElseGet(MessageProperties::new);
+        Message amqpMessage = template.getMessageConverter().toMessage(message, messageProperties);
+        template.send(routingKey, amqpMessage);
     }
 
     /**

--- a/vividus-plugin-rabbitmq/src/test/java/org/vividus/steps/rabbitmq/RabbitMqStepsTests.java
+++ b/vividus-plugin-rabbitmq/src/test/java/org/vividus/steps/rabbitmq/RabbitMqStepsTests.java
@@ -16,10 +16,13 @@
 
 package org.vividus.steps.rabbitmq;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -28,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Map;
@@ -36,15 +40,22 @@ import java.util.function.BiConsumer;
 
 import javax.net.ssl.SSLContext;
 
+import org.jbehave.core.model.ExamplesTable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.vividus.context.VariableContext;
 import org.vividus.softassert.ISoftAssert;
+import org.vividus.testcontext.SimpleTestContext;
 import org.vividus.util.property.IPropertyParser;
 import org.vividus.variable.VariableScope;
 
@@ -79,14 +90,49 @@ class RabbitMqStepsTests
     @Mock private ISoftAssert softAssert;
 
     @Test
+    void shouldFailWhenMessagePropertiesTableHasNotExactlyOneRow()
+    {
+        var steps = createSteps(Map.of());
+        var table = new ExamplesTable("|contentType|\n|application/json|\n|text/plain|");
+        var exception = assertThrows(IllegalArgumentException.class, () -> steps.setMessageProperties(table));
+        assertEquals("Exactly one row is expected in the message properties table, but got 2",
+                exception.getMessage());
+    }
+
+    @Test
     void shouldPublishMessage()
+    {
+        var converter = mock(MessageConverter.class);
+        var amqpMessage = mock(Message.class);
+        withMockedRabbit((factories, templates) ->
+        {
+            var steps = createSteps(Map.of(BROKER + SUFFIX_HOST, HOST_LOCAL));
+            var template = templates.constructed().get(0);
+            when(template.getMessageConverter()).thenReturn(converter);
+            when(converter.toMessage(eq(MESSAGE_BODY), any(MessageProperties.class))).thenReturn(amqpMessage);
+            steps.publishMessage(MESSAGE_BODY, ROUTING_KEY, BROKER);
+            verify(template).send(ROUTING_KEY, amqpMessage);
+            verify(factories.constructed().get(0), never()).setPort(anyInt());
+        });
+    }
+
+    @Test
+    void shouldPublishMessageWithProperties()
     {
         withMockedRabbit((factories, templates) ->
         {
             var steps = createSteps(Map.of(BROKER + SUFFIX_HOST, HOST_LOCAL));
+            var template = templates.constructed().get(0);
+            when(template.getMessageConverter()).thenReturn(new SimpleMessageConverter());
+            steps.setMessageProperties(new ExamplesTable("|messageId|appId|\n|12345|myApp|"));
             steps.publishMessage(MESSAGE_BODY, ROUTING_KEY, BROKER);
-            verify(templates.constructed().get(0)).convertAndSend(ROUTING_KEY, MESSAGE_BODY);
-            verify(factories.constructed().get(0), never()).setPort(anyInt());
+
+            var messageCaptor = ArgumentCaptor.forClass(Message.class);
+            verify(template).send(eq(ROUTING_KEY), messageCaptor.capture());
+            var message = messageCaptor.getValue();
+            assertArrayEquals(MESSAGE_BODY.getBytes(StandardCharsets.UTF_8), message.getBody());
+            assertEquals("12345", message.getMessageProperties().getMessageId());
+            assertEquals("myApp", message.getMessageProperties().getAppId());
         });
     }
 
@@ -253,7 +299,7 @@ class RabbitMqStepsTests
     private RabbitMqSteps createSteps(Map<String, String> templateConfig)
     {
         when(propertyParser.getPropertyValuesByPrefix(RABBITMQ_PREFIX)).thenReturn(templateConfig);
-        return new RabbitMqSteps(propertyParser, variableContext, softAssert);
+        return new RabbitMqSteps(propertyParser, new SimpleTestContext(), variableContext, softAssert);
     }
 
     private static String noConfigurationMessage(String brokerKey)

--- a/vividus-tests/src/main/resources/story/system/RabbitMQ.story
+++ b/vividus-tests/src/main/resources/story/system/RabbitMQ.story
@@ -3,6 +3,9 @@ Meta:
 
 Scenario: Produce/consume messages to/from RabbitMQ
 Given I initialize scenario variable `message` with value `#{generate(regexify '[a-z]{8}')}`
+When I set RabbitMQ message properties:
+|messageId                       |appId  |
+|#{generate(regexify '[0-9]{8}')}|vividus|
 When I publish message `${message}` with routing key `test_queue` to RabbitMQ broker `cloudamqp`
 When I retrieve message from queue `test_queue` of RabbitMQ broker `cloudamqp` with `PT60S` timeout and save it to scenario variable `receivedMessage`
 Then `${message}` is equal to `${receivedMessage}`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure AMQP message properties (e.g., messageId, appId, contentType, correlationId) for the next RabbitMQ publish; properties apply to the immediately following message only.

* **Behavior Change / Validation**
  * Properties input must be a single-row specification; invalid row counts produce a clear validation error.

* **Documentation**
  * Added docs and examples showing how to set properties and publish a message with a routing key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->