### PR TITLE
Replace disappearance wait step as it doesnt handle multiple elements

### DIFF
--- a/docs/modules/plugins/partials/ui-wait-element-state-steps.adoc
+++ b/docs/modules/plugins/partials/ui-wait-element-state-steps.adoc
@@ -17,9 +17,9 @@ When I wait until element located by `$locator` appears
 When I wait until element located by `id(welcome-image)` appears
 ----
 
-=== Wait for element disappearance
+=== Wait for elements disappearance
 
-Waits for disappearance of the element by the locator.
+Waits for disappearance of all elements by the locator.
 
 NOTE: If the element doesn't exist on the page/context, the step will immediately complete successfully.
 Checking the element on the page (if needed) should be done in a separate step (e.g. <<_wait_for_element_appearance>> or xref:plugin-html.adoc#_validate_elements[Validate elements]).
@@ -28,15 +28,21 @@ WARNING: It's forbidden to use <<_visibility_types>> in the locator.
 
 [source,gherkin]
 ----
+When I wait until all elements located by `$locator` disappear
+----
+
+_Deprecated syntax (will be removed in VIVIDUS 0.7.0)_:
+[source,gherkin]
+----
 When I wait until element located by `$locator` disappears
 ----
 
 * `$locator` - <<_locator>>.
 
-.Wait for disappearance of the element with the specified name
+.Wait for disappearance of the elements with the specified name
 [source,gherkin]
 ----
-When I wait until element located by `id(welcome-image)` disappears
+When I wait until all elements located by `id(welcome-image)` disappear
 ----
 
 === Wait for element with specified state using polling interval

--- a/vividus-extension-selenium/src/main/java/org/vividus/steps/ui/GenericWaitSteps.java
+++ b/vividus-extension-selenium/src/main/java/org/vividus/steps/ui/GenericWaitSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.vividus.annotation.Replacement;
 import org.vividus.selenium.locator.Locator;
 import org.vividus.softassert.ISoftAssert;
 import org.vividus.steps.ComparisonRule;
@@ -47,6 +48,7 @@ import org.vividus.ui.action.search.Visibility;
 import org.vividus.ui.context.IUiContext;
 import org.vividus.ui.monitor.TakeScreenshotOnFailure;
 
+@SuppressWarnings("PMD.ExcessiveImports")
 @TakeScreenshotOnFailure
 public class GenericWaitSteps
 {
@@ -103,7 +105,12 @@ public class GenericWaitSteps
      * Step supports only <b>VISIBLE</b> elements waiting. If locator will be configured to <b>ALL</b>
      * or <b>INVISIBLE</b> exception will be thrown.
      * @param locator locator to locate element
+     * @deprecated Current step has invalid behavior when there is more than one element on a page, use step instead:
+     * When I wait until all elements located by `$locator` disappear
      */
+    @Deprecated(since = "0.6.17", forRemoval = true)
+    @Replacement(versionToRemoveStep = "0.7.0",
+            replacementFormatPattern = "When I wait until all elements located by `%1$s` disappear")
     @When("I wait until element located by `$locator` disappears")
     public void waitForElementDisappearance(Locator locator)
     {

--- a/vividus-extension-selenium/src/main/resources/steps/defaults/ui.steps
+++ b/vividus-extension-selenium/src/main/resources/steps/defaults/ui.steps
@@ -1,0 +1,2 @@
+Composite: When I wait until all elements located by `$locator` disappear
+When I wait until number of elements located by `<locator>` is equal to 0

--- a/vividus-tests/src/main/resources/story/integration/WaitStepsTests.story
+++ b/vividus-tests/src/main/resources/story/integration/WaitStepsTests.story
@@ -11,11 +11,13 @@ When I change context to element located by `cssSelector(.external)`
 When I COMPARE_AGAINST baseline with name `moving-element-after-stopping#{eval(isWindows ? '-windows' : '')}`
 When I reset context
 
-Scenario: Step verification "When I wait until element located by '$locator' disappears"
+Scenario: Step verification: "When I wait until all elements located by `$locator` disappear", "When I wait until element located by '$locator' disappears"
 Given I am on page with URL `${vividus-test-site-url}/elementState.html`
 Given I initialize scenario variable `disappearing-locator` with value `By.id(element-to-hide)`
 Then number of elements found by `${disappearing-locator}` is equal to `1`
 When I click on element located by `id(button-hide)`
+When I wait until all elements located by `${disappearing-locator}` disappear
+!-- Deprecated
 When I wait until element located by `${disappearing-locator}` disappears
 Then number of elements found by `${disappearing-locator}` is equal to `0`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote disappearance guidance to describe waiting for all matched elements to disappear and noted that the step succeeds immediately if no match exists; reiterated locator restrictions.

* **New Features**
  * Added step syntax to wait until all elements located by a locator disappear and a variant that checks count equals 0.

* **Breaking Changes**
  * Single-element disappearance step deprecated (marked for removal in v0.7.0); migrate to the new "all elements disappear" pattern.

* **Tests**
  * Updated scenarios to use the new step phrasing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vividus-framework/vividus/pull/6649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->