### PR TITLE
Revert "Bump com.browserstack:browserstack-local-java from 1.1.8 to 1.1.9 (#6690)"

### DIFF
--- a/vividus-plugin-browserstack/build.gradle
+++ b/vividus-plugin-browserstack/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation platform(libs.slf4j.bom)
     implementation(libs.slf4j.api)
     implementation('com.browserstack:automate-client-java:0.15')
-    implementation('com.browserstack:browserstack-local-java:1.1.9')
+    implementation('com.browserstack:browserstack-local-java:1.1.8')
 
     testImplementation platform(libs.junit.bom)
     testImplementation(libs.junit.jupiter)


### PR DESCRIPTION
This reverts commit fb2f16456dd71a8ef07979f647442c7eb6ae84d2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the BrowserStack Local component to a different version, which may improve compatibility and stability during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->