### PR TITLE
[plugin-browserstack] Disable SSL certificate validation for BS Local when proxy enabled

### DIFF
--- a/vividus-plugin-browserstack/src/main/java/org/vividus/selenium/browserstack/BrowserStackLocalManager.java
+++ b/vividus-plugin-browserstack/src/main/java/org/vividus/selenium/browserstack/BrowserStackLocalManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,6 +150,7 @@ public class BrowserStackLocalManager implements TunnelManager<TunnelOptions>
                 String pac = ResourceUtils.createTempFile("pac-browserstack-" + localIdentifier, ".js",
                         String.format(PAC_FORMAT, options.getProxy())).toString();
                 parameters.put("-pac-file", pac);
+                parameters.put("-disable-ssl-validation", "");
             }
 
             this.localParameters = parameters;

--- a/vividus-plugin-browserstack/src/test/java/org/vividus/selenium/browserstack/BrowserStackLocalManagerTests.java
+++ b/vividus-plugin-browserstack/src/test/java/org/vividus/selenium/browserstack/BrowserStackLocalManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,13 +86,14 @@ class BrowserStackLocalManagerTests
             Local local = localMocks.constructed().get(0);
             verify(local).start(optionsCaptor.capture());
             Map<String, String> parameters = optionsCaptor.getValue();
-            assertThat(parameters, aMapWithSize(4));
+            assertThat(parameters, aMapWithSize(5));
             verifyParameters(parameters, mainIdentifier);
             String pacPath = parameters.get("-pac-file");
             String pac = Files.readString(Paths.get(pacPath), StandardCharsets.UTF_8);
             assertEquals("function FindProxyForURL(url, host) "
                     + "{ if (shExpMatch(host, \"*.browserstack.com\")) { return \"DIRECT\"; }"
                     + "return \"PROXY localhost:52377\"; }", pac);
+            assertEquals("", parameters.get("-disable-ssl-validation"));
             assertTrue(manager.isStarted());
 
             String reusedIdentifier = CompletableFuture.supplyAsync(() ->


### PR DESCRIPTION
Fixes the error:
```
com.browserstack.local.LocalException: Looks like you have SSL inspection enabled. You can either bypass *.browserstack.com or disable SSL inspection entirely for BrowserStack local to connect.
 Please contact your enterprise network administrator for more details. If the issue persists, please contact our support team.
 Alternatively, you can pass root CA certificates to binary using the flags --use-ca-certificate <.pem file> for win and --use-system-installed-ca for mac/linux
	at com.browserstack.local.Local.start(Local.java:83)
	at org.vividus.selenium.browserstack.BrowserStackLocalManager$BrowserStackLocalConnection.startConnection(BrowserStackLocalManager.java:168)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BrowserStack Local startup settings to include SSL validation disabling, helping tunnel connections work more reliably in proxy-based setups.
  * Adjusted related checks to match the updated connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->