### PR TITLE
Add object pool steps

### DIFF
--- a/docs/modules/commons/pages/vividus-steps.adoc
+++ b/docs/modules/commons/pages/vividus-steps.adoc
@@ -495,6 +495,80 @@ When I wait `$timeout` with `$pollingTimeout` polling until file matching `$file
 When I wait `PT30S` with `PT1S` polling until file matching `report-\d+\.csv` appears in directory `/tmp/reports` and save path to SCENARIO variable `report-path`
 ----
 
+== Object pool
+
+Think of an object pool as a shared basket of items that your tests can borrow from. You fill the basket once with a
+list of items (for example, a set of test user accounts), and then, whenever a test needs one, it picks an item out of
+the basket at random. Each item can be held by only one test at a time, so tests running side by side never accidentally
+grab the same account and interfere with each other.
+
+This is handy whenever you have a limited number of shared resources - such as logins, licenses, or reservations - that
+must be shared fairly across many tests.
+
+=== Deciding whether items go back into the basket
+
+By default, once a test takes an item out of the basket, that item stays out and is considered used up. If you would
+rather put every borrowed item back into the basket at the end of each story - so that later stories can reuse the same
+items - turn on the setting below.
+
+[cols="3,1,1,3", options="header"]
+|===
+|Setting |Possible values |Default |What it does
+
+|`object-pool.return-objects-after-story-completion`
+|`true` / `false`
+|`false`
+|When `true`, every item a story borrowed is returned to its basket once the story finishes, making it available again
+for the next stories. When `false`, borrowed items are not returned and are treated as used up.
+|===
+
+=== Fill the basket (initialize an object pool)
+
+Fills a named basket with a list of items. Each basket can be filled only once - trying to fill a basket that already
+exists will stop the test with an error. Every row of the table becomes one item in the basket, and the column headers
+become the details of that item.
+
+[source,gherkin]
+----
+Given I initialize object pool `$poolName` with data:$data
+----
+* `$poolName` - The name you give to the basket so you can refer to it later.
+* `$data` - The xref:ROOT:glossary.adoc#_examplestable[table] of items to put into the basket. Each row is one item.
+
+.Fill a basket named "credentials" with three user accounts
+[source,gherkin]
+----
+Given I initialize object pool `credentials` with data:
+|login |password|
+|user-1|pass-1  |
+|user-2|pass-2  |
+|user-3|pass-3  |
+----
+
+=== Take an item from the basket
+
+Picks a random item out of the basket and stores it, so you can use its details later in the test. The item is removed
+from the basket, so no other test can pick the same one until it is returned (see the setting above).
+
+[source,gherkin]
+----
+When I take object from pool `$poolName` and save it to $scopes variable `$variableName`
+----
+* `$poolName` - The name of the basket to pick an item from.
+* `$scopes` - xref:commons:variables.adoc#_scopes[How long the stored item should stay available] (for example, for the
+current scenario or the whole story).
+* `$variableName` - The name you give to the item so you can use its details later.
+
+Once stored, you can read the details of the picked item by its column names, for example `${credential.login}` and
+`${credential.password}`.
+
+.Take one user account from the "credentials" basket and use it
+[source,gherkin]
+----
+When I take object from pool `credentials` and save it to scenario variable `credential`
+Then `${credential.login}` matches `user-[1-3]`
+----
+
 == ZIP archives
 === Save ZIP archive entries
 

--- a/vividus-plugin-json/src/main/java/org/vividus/json/transformer/JsonTableTransformer.java
+++ b/vividus-plugin-json/src/main/java/org/vividus/json/transformer/JsonTableTransformer.java
@@ -33,6 +33,7 @@ import org.vividus.transformer.ExtendedTableTransformer;
 import org.vividus.util.ExamplesTableProcessor;
 import org.vividus.util.ResourceUtils;
 import org.vividus.util.json.JsonPathUtils;
+import org.vividus.util.json.JsonUtils;
 
 public class JsonTableTransformer implements ExtendedTableTransformer
 {
@@ -40,10 +41,12 @@ public class JsonTableTransformer implements ExtendedTableTransformer
     private static final String PATH_PROPERTY_KEY = "path";
 
     private final VariableContext variableContext;
+    private final JsonUtils jsonUtils;
 
-    public JsonTableTransformer(VariableContext variableContext)
+    public JsonTableTransformer(VariableContext variableContext, JsonUtils jsonUtils)
     {
         this.variableContext = variableContext;
+        this.jsonUtils = jsonUtils;
     }
 
     @SuppressWarnings("unchecked")
@@ -71,7 +74,7 @@ public class JsonTableTransformer implements ExtendedTableTransformer
             List<List<String>> values = jsonDataMapper.apply(columnsPerJsonPaths.values()).stream().map(e ->
             {
                 List<Object> columnValues = e instanceof List ? (List<Object>) e : Collections.singletonList(e);
-                return columnValues.stream().map(String::valueOf).toList();
+                return columnValues.stream().map(this::convertColumnValue).toList();
             }).toList();
             return ExamplesTableProcessor.buildExamplesTableFromColumns(columnsPerJsonPaths.keySet(), values,
                     tableProperties);
@@ -80,5 +83,10 @@ public class JsonTableTransformer implements ExtendedTableTransformer
         {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private String convertColumnValue(Object columnValue)
+    {
+        return columnValue instanceof Map ? jsonUtils.toJson(columnValue) : String.valueOf(columnValue);
     }
 }

--- a/vividus-plugin-json/src/test/java/org/vividus/json/transformer/JsonTableTransformerTests.java
+++ b/vividus-plugin-json/src/test/java/org/vividus/json/transformer/JsonTableTransformerTests.java
@@ -29,22 +29,24 @@ import org.apache.commons.lang3.StringUtils;
 import org.jbehave.core.configuration.Keywords;
 import org.jbehave.core.model.ExamplesTable.TableProperties;
 import org.jbehave.core.steps.ParameterConverters;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.vividus.context.VariableContext;
 import org.vividus.util.ResourceUtils;
+import org.vividus.util.json.JsonUtils;
 
 @ExtendWith(MockitoExtension.class)
 class JsonTableTransformerTests
 {
     private static final String VAR_NAME = "varName";
+    private static final String VARIABLE_NAME_PROPERTY = "variableName=";
     private static final String EXAMPLE_TABLE_COLUMNS_CONFIG = ",columns=column_code=$.superCodes..code;"
             + "column_codeSystem=$.superCodes..codeSystem;column_type=$.superCodes..type";
     private static final String EXPECTED_TABLE = """
@@ -57,7 +59,13 @@ class JsonTableTransformerTests
             |1|true|F|""";
 
     @Mock private VariableContext variableContext;
-    @InjectMocks private JsonTableTransformer jsonTableTransformer;
+    private JsonTableTransformer jsonTableTransformer;
+
+    @BeforeEach
+    void init()
+    {
+        jsonTableTransformer = new JsonTableTransformer(variableContext, new JsonUtils());
+    }
 
     @Test
     void shouldTransformFromVariableToComplexTable()
@@ -94,7 +102,7 @@ class JsonTableTransformerTests
     {
         when(variableContext.getVariable(VAR_NAME)).thenReturn(readJsonData());
 
-        var tableProperties = createProperties("variableName=" + VAR_NAME + columnsParam);
+        var tableProperties = createProperties(VARIABLE_NAME_PROPERTY + VAR_NAME + columnsParam);
         var table = jsonTableTransformer.transform(StringUtils.EMPTY, null, tableProperties);
         assertEquals(EXPECTED_TABLE, table);
     }
@@ -107,6 +115,16 @@ class JsonTableTransformerTests
                 columnsPrefix + "\ncolumn_type=$.superCodes..type",
                 columnsPrefix + "column_type=$.superCodes..type"
         );
+    }
+
+    @Test
+    void shouldConvertObjectColumnValueToJson()
+    {
+        when(variableContext.getVariable(VAR_NAME)).thenReturn(readJsonData());
+
+        var tableProperties = createProperties(VARIABLE_NAME_PROPERTY + VAR_NAME + ",columns=object=$.simpleCodes[0]");
+        var table = jsonTableTransformer.transform(StringUtils.EMPTY, null, tableProperties);
+        assertEquals("|object|\n|{\"code\":\"1\",\"codeSystem\":\"VIVIDUS\"}|", table);
     }
 
     @Test

--- a/vividus-tests/src/main/resources/story/integration/ObjectPoolSteps.story
+++ b/vividus-tests/src/main/resources/story/integration/ObjectPoolSteps.story
@@ -1,0 +1,68 @@
+Meta:
+    @epic vividus-core
+
+Scenario: Take objects from the initialized object pool
+Given I initialize object pool `credentials` with data:
+|login |password|
+|user-1|pass-1  |
+|user-2|pass-2  |
+|user-3|pass-3  |
+
+When I take object from pool `credentials` and save it to scenario variable `firstCredential`
+When I take object from pool `credentials` and save it to scenario variable `secondCredential`
+When I take object from pool `credentials` and save it to scenario variable `thirdCredential`
+
+Given I initialize scenario variable `expectedJson` with value `[
+    {
+        "login": "user-1",
+        "password": "pass-1"
+    },
+    {
+        "login": "user-2",
+        "password": "pass-2"
+    },
+    {
+        "login": "user-3",
+        "password": "pass-3"
+    }
+]`
+
+Given I initialize scenario variable `actualJson` with value `[
+    {
+        "login": "${firstCredential.login}",
+        "password": "${firstCredential.password}"
+    },
+    {
+        "login": "${secondCredential.login}",
+        "password": "${secondCredential.password}"
+    },
+    {
+        "login": "${thirdCredential.login}",
+        "password": "${thirdCredential.password}"
+    }
+]`
+
+Then JSON element from `${actualJson}` by JSON path `$` is equal to `${expectedJson}`IGNORING_ARRAY_ORDER
+
+
+Scenario: Take objects from object pool with objects having nested structures
+Given I initialize scenario variable `user` with value `{
+    "login": "user-1",
+    "password": "pass-1",
+    "roles": [
+        "admin",
+        "editor"
+    ],
+    "address": {
+        "city": "New York",
+        "zip": "10001"
+    }
+}`
+
+Given I initialize scenario variable `users` with value `[${user}]`
+
+Given I initialize object pool `usersPool` with data:
+{transformer=FROM_JSON, variableName=users, columns=json=$}
+
+When I take object from pool `usersPool` and save it to scenario variable `userJson`
+Then JSON element from `${userJson.json}` by JSON path `$` is equal to `${user}`

--- a/vividus/src/main/java/org/vividus/steps/ObjectPoolSteps.java
+++ b/vividus/src/main/java/org/vividus/steps/ObjectPoolSteps.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.steps;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import org.apache.commons.lang3.Validate;
+import org.jbehave.core.annotations.AfterStory;
+import org.jbehave.core.annotations.Given;
+import org.jbehave.core.annotations.When;
+import org.jbehave.core.model.ExamplesTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.vividus.context.VariableContext;
+import org.vividus.testcontext.TestContext;
+import org.vividus.variable.VariableScope;
+
+public class ObjectPoolSteps
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ObjectPoolSteps.class);
+
+    private static final Object TAKEN_OBJECTS_KEY = ObjectPoolSteps.class;
+
+    private final boolean returnObjectsAfterStoryCompletion;
+    private final TestContext testContext;
+    private final VariableContext variableContext;
+
+    private final Map<String, ObjectPool> pools = new ConcurrentHashMap<>();
+
+    public ObjectPoolSteps(boolean returnObjectsAfterStoryCompletion, TestContext testContext,
+            VariableContext variableContext)
+    {
+        this.returnObjectsAfterStoryCompletion = returnObjectsAfterStoryCompletion;
+        this.testContext = testContext;
+        this.variableContext = variableContext;
+    }
+
+    /**
+     * Initializes an object pool with the provided data. The pool is shared between all threads and stories, so it
+     * can be populated only once: any attempt to initialize an already existing pool results in an error.
+     *
+     * @param poolName The unique name of the object pool.
+     * @param data     The xref:ROOT:glossary.adoc#_examplestable[ExamplesTable] with the objects to put into the pool,
+     *                 every row is stored as a separate object represented by a map of the column names to the values.
+     */
+    @Given("I initialize object pool `$poolName` with data:$data")
+    public void initializeObjectPool(String poolName, ExamplesTable data)
+    {
+        List<Map<String, String>> objects = data.getRows();
+        Collections.shuffle(objects);
+        ObjectPool existingPool = pools.putIfAbsent(poolName, new ObjectPool(objects));
+        Validate.validState(existingPool == null, "The object pool with the name '%s' is already initialized",
+                poolName);
+        LOGGER.atInfo().addArgument(poolName).addArgument(objects::size)
+                .log("The object pool with the name '{}' is initialized with {} element(s)");
+    }
+
+    /**
+     * Takes a random object from the pool and saves it to the variable. The taken object is removed from the pool, so
+     * it can't be taken again until it is returned back. The objects are returned back to the pool after the story only
+     * if the {@code object-pool.return-objects-after-story-completion} property is set to {@code true}.
+     *
+     * @param poolName     The name of the object pool to take the object from.
+     * @param scopes       The set (comma separated list of scopes e.g.: STORY, NEXT_BATCHES) of variable's scope<br>
+     * <i>Available scopes:</i>
+     * <ul>
+     * <li><b>STEP</b> - the variable will be available only within the step,
+     * <li><b>SCENARIO</b> - the variable will be available only within the scenario,
+     * <li><b>STORY</b> - the variable will be available within the whole story,
+     * <li><b>NEXT_BATCHES</b> - the variable will be available starting from next batch
+     * </ul>
+     * @param variableName The name of the variable to store the taken object.
+     */
+    @When("I take object from pool `$poolName` and save it to $scopes variable `$variableName`")
+    public void takeObjectFromPool(String poolName, Set<VariableScope> scopes, String variableName)
+    {
+        ObjectPool pool = pools.get(poolName);
+        Validate.validState(pool != null, "The object pool with the name '%s' is not initialized", poolName);
+        Map<String, String> object = pool.take(poolName);
+        if (returnObjectsAfterStoryCompletion)
+        {
+            getTakenObjects().computeIfAbsent(poolName, key -> new ArrayList<>()).add(object);
+        }
+        variableContext.putVariable(scopes, variableName, object);
+    }
+
+    @AfterStory
+    public void returnObjectsToPools()
+    {
+        if (returnObjectsAfterStoryCompletion)
+        {
+            getTakenObjects().forEach((poolName, objects) -> objects.forEach(pools.get(poolName)::giveBack));
+        }
+    }
+
+    private Map<String, List<Map<String, String>>> getTakenObjects()
+    {
+        return testContext.get(TAKEN_OBJECTS_KEY, HashMap::new);
+    }
+
+    private static final class ObjectPool
+    {
+        private final Deque<Map<String, String>> objects;
+
+        private ObjectPool(List<Map<String, String>> objects)
+        {
+            this.objects = new ConcurrentLinkedDeque<>(objects);
+        }
+
+        private Map<String, String> take(String poolName)
+        {
+            Map<String, String> object = objects.poll();
+            Validate.validState(object != null, "The object pool with the name '%s' is empty", poolName);
+            return object;
+        }
+
+        private void giveBack(Map<String, String> object)
+        {
+            objects.add(object);
+        }
+    }
+}

--- a/vividus/src/main/resources/org/vividus/spring-steps.xml
+++ b/vividus/src/main/resources/org/vividus/spring-steps.xml
@@ -31,6 +31,11 @@
     <bean id="debugSteps" class="org.vividus.steps.DebugSteps" />
     <bean id="executableSteps" class="org.vividus.steps.ExecutableSteps" />
     <bean id="fileSteps" class="org.vividus.steps.FileSteps" />
+    <bean id="objectPoolSteps" class="org.vividus.steps.ObjectPoolSteps">
+        <constructor-arg index="0" value="${object-pool.return-objects-after-story-completion}" />
+        <constructor-arg index="1" ref="testContext" />
+        <constructor-arg index="2" ref="variableContext" />
+    </bean>
     <bean id="setupSteps" class="org.vividus.steps.LoggingExecutionResultsSteps" />
 
     <bean class="org.vividus.publishing.DiffAttachmentPublisher">
@@ -42,6 +47,7 @@
         <idref bean="assertSteps" />
         <idref bean="variablesSteps" />
         <idref bean="fileSteps" />
+        <idref bean="objectPoolSteps" />
         <idref bean="executableSteps" />
         <idref bean="setupSteps" />
         <idref bean="debugSteps" />

--- a/vividus/src/main/resources/properties/defaults/default.properties
+++ b/vividus/src/main/resources/properties/defaults/default.properties
@@ -92,6 +92,8 @@ soft-assert.stack-trace-filter.exclusions=org.vividus.softassert
 
 template-processor.resolve-bdd-variables=false
 
+object-pool.return-objects-after-story-completion=false
+
 statistics.folder=${output.directory}/statistics
 statistics.print-failures=false
 

--- a/vividus/src/test/java/org/vividus/steps/ObjectPoolStepsTests.java
+++ b/vividus/src/test/java/org/vividus/steps/ObjectPoolStepsTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vividus.steps;
+
+import static com.github.valfirst.slf4jtest.LoggingEvent.info;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import com.github.valfirst.slf4jtest.TestLoggerFactoryExtension;
+
+import org.jbehave.core.model.ExamplesTable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.vividus.context.VariableContext;
+import org.vividus.testcontext.SimpleTestContext;
+import org.vividus.testcontext.TestContext;
+import org.vividus.variable.VariableScope;
+
+@ExtendWith({ MockitoExtension.class, TestLoggerFactoryExtension.class })
+class ObjectPoolStepsTests
+{
+    private static final String POOL_NAME = "users";
+    private static final String VARIABLE_NAME = "user";
+    private static final String POOL_IS_EMPTY_ERROR = "The object pool with the name 'users' is empty";
+    private static final String INIT_LOG_MESSAGE = "The object pool with the name '{}' is initialized with {} "
+            + "element(s)";
+    private static final Set<VariableScope> SCOPES = Set.of(VariableScope.SCENARIO);
+    private static final ExamplesTable DATA = new ExamplesTable("""
+            |login  |password|
+            |user-1 |pass-1  |
+            |user-2 |pass-2  |
+            |user-3 |pass-3  |""");
+
+    private final List<Object> takenObjects = new ArrayList<>();
+
+    @Mock private VariableContext variableContext;
+
+    private final TestContext testContext = new SimpleTestContext();
+    private final TestLogger logger = TestLoggerFactory.getTestLogger(ObjectPoolSteps.class);
+
+    @Test
+    void shouldTakeRandomDistinctObjectsFromPool()
+    {
+        captureTakenObjects();
+        ObjectPoolSteps steps = new ObjectPoolSteps(false, testContext, variableContext);
+        steps.initializeObjectPool(POOL_NAME, DATA);
+
+        int poolSize = DATA.getRows().size();
+        drainPool(steps, poolSize);
+
+        assertEquals(poolSize, takenObjects.size());
+        assertEquals(poolSize, Set.copyOf(takenObjects).size());
+        assertTrue(DATA.getRows().containsAll(takenObjects));
+        assertThat(logger.getLoggingEvents(), is(List.of(info(INIT_LOG_MESSAGE, POOL_NAME, 3))));
+    }
+
+    @Test
+    void shouldProhibitRepeatedInitializationOfSamePool()
+    {
+        ObjectPoolSteps steps = new ObjectPoolSteps(false, testContext, variableContext);
+        steps.initializeObjectPool(POOL_NAME, DATA);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> steps.initializeObjectPool(POOL_NAME, DATA));
+        assertEquals("The object pool with the name 'users' is already initialized", exception.getMessage());
+        assertThat(logger.getLoggingEvents(), is(List.of(info(INIT_LOG_MESSAGE, POOL_NAME, 3))));
+    }
+
+    @Test
+    void shouldFailToTakeObjectFromNotInitializedPool()
+    {
+        ObjectPoolSteps steps = new ObjectPoolSteps(false, testContext, variableContext);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> steps.takeObjectFromPool(POOL_NAME, SCOPES, VARIABLE_NAME));
+        assertEquals("The object pool with the name 'users' is not initialized", exception.getMessage());
+        verifyNoInteractions(variableContext);
+        assertThat(logger.getLoggingEvents(), is(List.of()));
+    }
+
+    @Test
+    void shouldFailToTakeObjectFromEmptyPool()
+    {
+        ObjectPoolSteps steps = new ObjectPoolSteps(false, testContext, variableContext);
+        steps.initializeObjectPool(POOL_NAME, new ExamplesTable("|login|\n|user-1|"));
+        steps.takeObjectFromPool(POOL_NAME, SCOPES, VARIABLE_NAME);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> steps.takeObjectFromPool(POOL_NAME, SCOPES, VARIABLE_NAME));
+        assertEquals(POOL_IS_EMPTY_ERROR, exception.getMessage());
+        assertThat(logger.getLoggingEvents(), is(List.of(info(INIT_LOG_MESSAGE, POOL_NAME, 1))));
+    }
+
+    @Test
+    void shouldReturnObjectsToPoolAfterStoryWhenEnabled()
+    {
+        captureTakenObjects();
+        ObjectPoolSteps steps = new ObjectPoolSteps(true, testContext, variableContext);
+        int poolSize = DATA.getRows().size();
+        steps.initializeObjectPool(POOL_NAME, DATA);
+
+        drainPool(steps, poolSize);
+        steps.returnObjectsToPools();
+        drainPool(steps, poolSize);
+
+        List<Object> firstStoryObjects = takenObjects.subList(0, poolSize);
+        List<Object> secondStoryObjects = takenObjects.subList(poolSize, 2 * poolSize);
+        assertEquals(Set.copyOf(firstStoryObjects), Set.copyOf(secondStoryObjects));
+    }
+
+    @Test
+    void shouldNotReturnObjectsToPoolAfterStoryWhenDisabled()
+    {
+        ObjectPoolSteps steps = new ObjectPoolSteps(false, testContext, variableContext);
+        steps.initializeObjectPool(POOL_NAME, DATA);
+        drainPool(steps, DATA.getRows().size());
+
+        steps.returnObjectsToPools();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> steps.takeObjectFromPool(POOL_NAME, SCOPES, VARIABLE_NAME));
+        assertEquals(POOL_IS_EMPTY_ERROR, exception.getMessage());
+    }
+
+    private void drainPool(ObjectPoolSteps steps, int poolSize)
+    {
+        for (int i = 0; i < poolSize; i++)
+        {
+            steps.takeObjectFromPool(POOL_NAME, SCOPES, VARIABLE_NAME);
+        }
+    }
+
+    private void captureTakenObjects()
+    {
+        doAnswer(invocation ->
+        {
+            takenObjects.add(invocation.getArgument(2));
+            return null;
+        }).when(variableContext).putVariable(eq(SCOPES), eq(VARIABLE_NAME), any());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added object pool support with steps to initialize named pools, borrow pooled objects into scenario variables, and optionally return borrowed objects after each story completion.
  - Introduced `object-pool.return-objects-after-story-completion` (default: `false`) to control the return behavior.
- **Bug Fixes**
  - Improved JSON table transformation so object-typed column values are rendered as JSON in example tables.
- **Documentation**
  - Documented the new “Object pool” steps, including integration scenarios and nested-structure examples.
- **Tests**
  - Added coverage for pool lifecycle, variable storage, return-after-story behavior, and updated JSON expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->