### PR TITLE
feat: migrate bootstrap version from 3.4.1 to 5.3.1 for vividus-plugin-applitools  module attachments

### DIFF
--- a/vividus-extension-visual-testing/src/main/resources/base-report.ftl
+++ b/vividus-extension-visual-testing/src/main/resources/base-report.ftl
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>Visual tests result table</title>
     <link rel="stylesheet" href="../../styles.css"/>
-    <link rel="stylesheet" href="../../webjars/bootstrap/3.4.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="../../webjars/bootstrap/5.3.1/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="../../webjars/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css">
     <link rel="stylesheet" href="../../webjars/vividus/style.css"/>
 </head>
@@ -17,6 +17,41 @@
     img {
         background: url('data:image/gif;base64,R0lGODlhCgAKAIAAAOXl5f///yH5BAAAAAAALAAAAAAKAAoAAAIRhB2ZhxoM3GMSykqd1VltzxQAOw==');
     }
+    .btn-default {
+        color: #333;
+        background-color: #fff;
+        border-color: #ccc;
+    }
+    .btn-default:hover,
+    .btn-default:focus,
+    .btn-default:active {
+        color: #333;
+        background-color: #e6e6e6;
+        border-color: #adadad;
+    }
+    .toggle.btn {
+        box-shadow: none;
+        border-radius: 4px;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+    }
+    .toggle.btn-success,
+    .toggle-off.btn-success {
+        color: #fff;
+        background-color: #5cb85c;
+        border-color: #4cae4c;
+    }
+    .toggle.btn-danger,
+    .toggle-on.btn-danger {
+        color: #fff;
+        background-color: #d9534f;
+        border-color: #d43f3a;
+    }
+    .toggle-handle.btn {
+        background-color: #fff;
+        border-color: #ccc;
+    }
     <@custom_css />
     </style>
     <div class="container-fluid">
@@ -25,52 +60,54 @@
         <h3>Baseline name: ${result.baselineName}</h3>
         <@custom_section />
         <#if compare>
-            <div class="col-md">
-                <#if hasBaseline>
-                    <label class="checkbox-inline">
+            <div class="row">
+                <div class="col-12 mb-2">
+                    <#if hasBaseline>
                         <input id="diffCheckBox" type="checkbox" data-toggle="toggle" data-on="Diff" data-off="Checkpoint" data-onstyle="danger" data-offstyle="success">
-                    </label>
-                </#if>
-                <@custom_controls />
-            </div>
-            <div class="col-md-6">
-                <p>Baseline</p>
-                <#if hasBaseline>
-                    <img class="img-responsive" src="data:image/png;base64,${freemarkerMethodCompressImage(result.baseline)}" />
-                <#else>
-                    <span>No baseline image</span>
-                </#if>
-            </div>
-            <div class="col-md-6">
-                <p>Checkpoint</p>
-                <#if hasBaseline>
-                    <#if result.diff?hasContent>
-                        <img id="diff" class="img-responsive" src="data:image/png;base64,${freemarkerMethodCompressImage(result.diff)}" />
-                    <#else>
-                        <span>No diff image</span>
                     </#if>
-                </#if>
-                <#if result.checkpoint?hasContent>
-                    <img id="checkpoint" class="img-responsive" src="data:image/png;base64,${freemarkerMethodCompressImage(result.checkpoint)}" />
-                <#else>
-                    <span>No checkpoint image</span>
-                </#if>
+                    <@custom_controls />
+                </div>
+                <div class="col-md-6">
+                    <p>Baseline</p>
+                    <#if hasBaseline>
+                        <img class="img-fluid" src="data:image/png;base64,${freemarkerMethodCompressImage(result.baseline)}" />
+                    <#else>
+                        <span>No baseline image</span>
+                    </#if>
+                </div>
+                <div class="col-md-6">
+                    <p>Checkpoint</p>
+                    <#if hasBaseline>
+                        <#if result.diff?hasContent>
+                            <img id="diff" class="img-fluid" src="data:image/png;base64,${freemarkerMethodCompressImage(result.diff)}" />
+                        <#else>
+                            <span>No diff image</span>
+                        </#if>
+                    </#if>
+                    <#if result.checkpoint?hasContent>
+                        <img id="checkpoint" class="img-fluid" src="data:image/png;base64,${freemarkerMethodCompressImage(result.checkpoint)}" />
+                    <#else>
+                        <span>No checkpoint image</span>
+                    </#if>
+                </div>
             </div>
         <#else>
-            <div class="col-md">
-                <p>Baseline</p>
-                <@custom_controls />
-                <#if result.checkpoint?hasContent>
-                    <img id="checkpoint" class="img-responsive" src="data:image/png;base64,${freemarkerMethodCompressImage(result.checkpoint)}" />
-                <#else>
-                    <span>No checkpoint image</span>
-                </#if>
+            <div class="row">
+                <div class="col-12">
+                    <p>Baseline</p>
+                    <@custom_controls />
+                    <#if result.checkpoint?hasContent>
+                        <img id="checkpoint" class="img-fluid" src="data:image/png;base64,${freemarkerMethodCompressImage(result.checkpoint)}" />
+                    <#else>
+                        <span>No checkpoint image</span>
+                    </#if>
+                </div>
             </div>
         </#if>
     </div>
 
     <script src="../../webjars/jquery/3.6.4/jquery.min.js"></script>
-    <script src="../../webjars/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <script src="../../webjars/bootstrap/5.3.1/js/bootstrap.min.js"></script>
     <script src="../../webjars/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
     <#if compare>
     <script type="text/javascript">

--- a/vividus-plugin-applitools/src/main/resources/applitools-visual-comparison.ftl
+++ b/vividus-plugin-applitools/src/main/resources/applitools-visual-comparison.ftl
@@ -28,14 +28,10 @@
 
 <#macro custom_controls>
 <#if result.stepUrl?hasContent>
-    <a href="${result.stepUrl}" target="_blank" class="btn btn-info applitools" role="button">Step editor
-        <span class="glyphicon glyphicon-wrench"></span>
-    </a>
+    <a href="${result.stepUrl}" target="_blank" class="btn btn-info applitools" role="button">Step editor</a>
 </#if>
 <#if result.batchUrl?hasContent>
-    <a href="${result.batchUrl}" target="_blank" class="btn btn-info applitools" role="button">Batch
-        <span class="glyphicon glyphicon-eye-open"></span>
-    </a>
+    <a href="${result.batchUrl}" target="_blank" class="btn btn-info applitools" role="button">Batch</a>
 </#if>
 </#macro>
 


### PR DESCRIPTION
Migrates the shared visual testing Allure attachment template from Bootstrap 3.4.1 to 5.3.1.

`base-report.ftl` is a FreeMarker macro used by:

- `visual-comparison.ftl` (local visual checks)
- `applitools-visual-comparison.ftl` (Applitools visual checks)
Both consumers are covered by this change.

Changes
- Switch Bootstrap CSS/JS references from 3.4.1 to 5.3.1
- Replace deprecated Bootstrap 3 APIs:
  - img-responsive → img-fluid
  - wrap layout columns in .row / .col-*
- Replace bootstrap-toggle with a native Bootstrap 5 form-switch for Diff/Checkpoint switching (same jQuery show/hide behavior)
- Remove Bootstrap 3 glyphicon icons from Applitools custom controls (not available in Bootstrap 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual testing reports to use Bootstrap 5.3.1 for improved responsive layout.
  * Refined the comparison view layout for baseline, checkpoint, and difference images with clearer organization.
  * Added graceful fallbacks so missing comparison images no longer break the display.
  * Simplified Applitools visual comparison link controls for a cleaner, more consistent button presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->