### PR TITLE
Add unescape JSON expression

### DIFF
--- a/docs/modules/commons/pages/expressions.adoc
+++ b/docs/modules/commons/pages/expressions.adoc
@@ -879,24 +879,7 @@ Escapes reserved characters in https://www.w3schools.com/html/html_entities.asp[
 |`M&amp;Ms`
 |===
 
-=== `escapeJSON`
-
-Escapes http://www.ietf.org/rfc/rfc4627.txt[reserved JSON characters]: converts any string into one that's properly escaped for inclusion in JSON as a value.
-
-[source, subs="+quotes"]
-----
-#{escapeJSON(*$input*)}
-----
-
-* *`$input`* - any string to be escaped
-
-.Escape JSON string
-|===
-|Expression |Result
-
-|`#{escapeJSON("abc"+"xyz")}`
-|`\"abc\"+\"xyz\"`
-|===
+include::partial$json-expressions.adoc[]
 
 === `quoteRegExp`
 

--- a/docs/modules/commons/partials/json-expressions.adoc
+++ b/docs/modules/commons/partials/json-expressions.adoc
@@ -1,0 +1,40 @@
+=== `escapeJSON`
+
+Escapes http://www.ietf.org/rfc/rfc8259.txt[reserved JSON characters]: converts any string into one that's properly escaped for inclusion in JSON as a value.
+
+[source, subs="+quotes"]
+----
+#{escapeJSON(*$input*)}
+----
+
+* *`$input`* - any string to be escaped
+
+.Escape JSON string
+|===
+|Expression |Result
+
+|`#{escapeJSON("abc"+"xyz")}`
+|`\"abc\"+\"xyz\"`
+|===
+
+=== `unescapeJSON`
+
+Unescapes a string containing http://www.ietf.org/rfc/rfc8259.txt[JSON] escape sequences to a string containing the actual Unicode characters corresponding to the escapes. Each expression application performs a single unescape pass, so for nested escaping apply the expression multiple times.
+
+[source, subs="+quotes"]
+----
+#{unescapeJSON(*$input*)}
+----
+
+* *`$input`* - any string to be unescaped
+
+.Unescape JSON string
+|===
+|Expression |Result
+
+|`#{unescapeJSON(\"abc\"+\"xyz\")}`
+|`"abc"+"xyz"`
+
+|`#{unescapeJSON(#{unescapeJSON(\\\"abc\\\"+\\\"xyz\\\")})}`
+|`"abc"+"xyz"`
+|===

--- a/docs/modules/plugins/pages/plugin-json.adoc
+++ b/docs/modules/plugins/pages/plugin-json.adoc
@@ -342,6 +342,8 @@ Given I initialize scenario variable `oneLineJson` with value `#{formatToOneLine
 )}`
 ----
 
+include::commons:partial$json-expressions.adoc[]
+
 == Steps
 
 :json-path: <<JSON Path, JSON path>>

--- a/docs/modules/plugins/partials/plugin-json-matchers.adoc
+++ b/docs/modules/plugins/partials/plugin-json-matchers.adoc
@@ -37,14 +37,14 @@ Then JSON element from `${actual-json}` by JSON path `$.store` is equal to `{"bo
 ----
 
 [TIP]
-As JSON do not support multi line strings if you want to improve readability use xref:commons:expressions.adoc#_escapejson[escapeJson] expression inside matcher
+As JSON do not support multi line strings if you want to improve readability use <<_escapejson,escapeJSON>> expression inside matcher
 
-.Validate entries with `escapeJson` expression
+.Validate entries with `escapeJSON` expression
 [source,gherkin]
 ----
 Then JSON element from `${actual-json}` by JSON path `$.store` is equal to `
 {
-  "book":"#{json-unit.matches:anyOf}#{escapeJson([
+  "book":"#{json-unit.matches:anyOf}#{escapeJSON([
     {
       "name":"Uladzimir Karatkevich",
       "available":true

--- a/vividus-tests/src/main/resources/story/integration/Expressions.story
+++ b/vividus-tests/src/main/resources/story/integration/Expressions.story
@@ -205,6 +205,16 @@ Given I initialize scenario variable `word` with value `"cowabunga"`
 Given I initialize scenario variable `json` with value `{"question":"what is #{escapeJson(${word})}?"}`
 Then `${json}` is equal to `{"question":"what is \"cowabunga\"?"}`
 
+Scenario: Should unescape nested JSON
+Given I initialize scenario variable `word` with value `"cowabunga"`
+Given I initialize scenario variable `onceEscaped` with value `#{escapeJSON(${word})}`
+Given I initialize scenario variable `twiceEscaped` with value `#{escapeJSON(${onceEscaped})}`
+Given I initialize scenario variable `thriceEscaped` with value `#{escapeJSON(${twiceEscaped})}`
+Then `#{unescapeJSON(${onceEscaped})}` is equal to `${word}`
+Then `#{unescapeJSON(${twiceEscaped})}` is equal to `${onceEscaped}`
+Then `#{unescapeJSON(#{unescapeJSON(${twiceEscaped})})}` is equal to `${word}`
+Then `#{unescapeJSON(#{unescapeJSON(#{unescapeJSON(${thriceEscaped})})})}` is equal to `${word}`
+
 Scenario: Should evaluate expression in multiline string
 Meta:
     @issueId 3501

--- a/vividus/src/main/java/org/vividus/expression/StringExpressionProcessors.java
+++ b/vividus/src/main/java/org/vividus/expression/StringExpressionProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public class StringExpressionProcessors extends DelegatingExpressionProcessor
             new SingleArgExpressionProcessor<>("loadResource",          ResourceUtils::loadResource),
             new SingleArgExpressionProcessor<>("escapeHTML",            StringEscapeUtils::escapeHtml4),
             new SingleArgExpressionProcessor<>("escapeJSON",            StringEscapeUtils::escapeJson),
+            new SingleArgExpressionProcessor<>("unescapeJSON",          StringEscapeUtils::unescapeJson),
             new SingleArgExpressionProcessor<>("quoteRegExp",           Pattern::quote),
             new BiArgExpressionProcessor<>("substringBefore",           StringUtils::substringBefore),
             new BiArgExpressionProcessor<>("substringAfter",            StringUtils::substringAfter),

--- a/vividus/src/test/java/org/vividus/expression/StringExpressionProcessorsTests.java
+++ b/vividus/src/test/java/org/vividus/expression/StringExpressionProcessorsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,8 @@ class StringExpressionProcessorsTests
                 arguments("anyOf(\\,)",                                                    ","),
                 arguments("escapeHTML(M&Ms)",                                              "M&amp;Ms"),
                 arguments("escapeJSON(\"abc\"\n\"xyz\")",                                  "\\\"abc\\\"\\n\\\"xyz\\\""),
+                arguments("unescapeJSON(\\\"abc\\\"\\n\\\"xyz\\\")",                       "\"abc\"\n\"xyz\""),
+                arguments("unescapeJSON(\\\\\\\"abc\\\\\\\")",                             "\\\"abc\\\""),
                 arguments("quoteRegExp(Customer(Username))",                               "\\QCustomer(Username)\\E"),
                 arguments("substringBefore(, a)",                                          ""),
                 arguments("substringBefore(abc, a)",                                       ""),
@@ -117,6 +119,14 @@ class StringExpressionProcessorsTests
     void testExecute(String expression, String expected)
     {
         assertEquals(expected, processors.execute(expression).get());
+    }
+
+    @Test
+    void shouldUnescapeNestedJsonEscaping()
+    {
+        String once = (String) processors.execute("unescapeJSON(\\\\\\\"abc\\\\\\\")").get();
+        assertEquals("\\\"abc\\\"", once);
+        assertEquals("\"abc\"", processors.execute("unescapeJSON(" + once + ")").get());
     }
 
     @ParameterizedTest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `unescapeJSON` expression for decoding JSON-escaped text.
  - Added shared documentation for `escapeJSON` and `unescapeJSON`, including syntax, inputs, examples, and nested escaping behavior.
  - Expanded JSON matcher examples and references.

- **Bug Fixes**
  - Improved handling and verification of nested JSON escaping and unescaping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->